### PR TITLE
Fixed error ParameterSpace.columns()

### DIFF
--- a/src/nest/conversion.py
+++ b/src/nest/conversion.py
@@ -6,7 +6,11 @@ import numpy
 
 from pyNN.parameters import Sequence
 
-def make_sli_compatible_single(value):
+def make_sli_compatible_single(value, preserve_scalar_arrays=False):
+    """
+    preserve_scalar_arrays == True can be set to not convert shape (1,)-arrays
+    to scalars.
+    """
     if isinstance(value, Sequence):
         return_value = value.value
     elif isinstance(value, numpy.ndarray):
@@ -15,7 +19,7 @@ def make_sli_compatible_single(value):
             # to my knowledge nest cannot handle that
             assert value.shape == (1,), "NEST expects 1 dimensional arrays"
             return_value = value[0].value
-        elif value.shape == (1,):
+        elif value.shape == (1,) and not preserve_scalar_arrays:
             # for nest.SetDefaults, there is a difference between an (1,)-array
             # and a scalar value
             return_value = value[0]
@@ -31,27 +35,30 @@ def make_sli_compatible_single(value):
     return return_value
 
 
-def make_sli_compatible(container):
+def make_sli_compatible(container, **kwargs):
     """
     Makes sure container only contains datatypes understood by the nest kernel.
 
     container can be scalar, a list or a dict.
+
+    preserve_scalar_arrays == True can be set to not convert shape (1,)-arrays
+    to scalars.
     """
 
     compatible = None
     if isinstance(container, list):
         compatible = []
         for value in container:
-            compatible.append(make_sli_compatible_single(value))
+            compatible.append(make_sli_compatible_single(value, **kwargs))
 
     elif isinstance(container, dict):
         compatible = {}
 
         for k,v in container.iteritems():
-            compatible[k] = make_sli_compatible_single(v)
+            compatible[k] = make_sli_compatible_single(v, **kwargs)
 
     else:
-        compatible = make_sli_compatible_single(container)
+        compatible = make_sli_compatible_single(container, **kwargs)
 
     return compatible
 

--- a/src/nest/projections.py
+++ b/src/nest/projections.py
@@ -177,10 +177,11 @@ class Projection(common.Projection):
             if connections:
                 source_mask = self.pre.id_to_index([x[0] for x in connections])
                 for name, value in connection_parameters.items():
-                    value = make_sli_compatible(value)
                     if name not in self._common_synapse_property_names:
+                        value = make_sli_compatible(value, preserve_scalar_arrays=True)
                         nest.SetStatus(connections, name, value[source_mask])
                     else:
+                        value = make_sli_compatible(value)
                         self._set_common_synapse_property(name, value)
 
     def _set_common_synapse_property(self, name, value):

--- a/test/unittests/test_nest.py
+++ b/test/unittests/test_nest.py
@@ -76,6 +76,8 @@ class TestProjection(unittest.TestCase):
         self.p1 = sim.Population(7, sim.IF_cond_exp())
         self.p2 = sim.Population(4, sim.IF_cond_exp())
         self.p3 = sim.Population(5, sim.IF_curr_alpha())
+        self.p4 = sim.Population(1, sim.IF_cond_exp())
+        self.p5 = sim.Population(1, sim.IF_cond_exp())
         self.syn_rnd = sim.StaticSynapse(weight=0.123, delay=0.5)
         self.syn_a2a = sim.StaticSynapse(weight=0.456, delay=0.4)
         self.random_connect = sim.FixedNumberPostConnector(n=2)
@@ -105,6 +107,15 @@ class TestProjection(unittest.TestCase):
                 column_names=["weight", "Wmax"])
             prj = sim.Projection(self.p1, self.p2, fromlist,
                      synapse_type=self.native_synapse_type())
+
+    def test_single_connection(self):
+        prj = sim.Projection(self.p4, self.p5, sim.AllToAllConnector(),
+                synapse_type=sim.StaticSynapse(weight=0.123))
+
+        weight = 0.456
+        prj.set(weight=weight)
+        self.assertEqual(prj.get("weight", format="array")[0], weight)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Problem:**
Setting attributes of shape `(n, 1)` fails for Projections.

**Reason:**
`lazyarray.partial_shape(...)` in `ParameterSpace.evaluate(...)` strips dimensions containing only as single element. However, this information is important for the `.columns()` and `.__iter__()` functions to distinguish cases where there is a single row from a single column. 

**Solution:**
The most straightforward solution was to copy `partial_shape(...)` from lazyarray but to omit the dimension-reduction step. As the `.__iter__()` and `.columns()` functions are the only ones accessing the `_evaluated_shape` attribute.
