### PR TITLE
sort neurons before recording by Brian

### DIFF
--- a/src/brian/recording.py
+++ b/src/brian/recording.py
@@ -53,7 +53,7 @@ class Recorder(recording.Recorder):
         #update StateMonitor.record and StateMonitor.recordindex
         if not variable is 'spikes':
             device = self._devices[variable]
-            device.record = numpy.fromiter(self.recorded[variable], dtype=int) - self.population.first_id
+            device.record = numpy.sort(numpy.fromiter(self.recorded[variable], dtype=int)) - self.population.first_id
             device.recordindex = dict((i,j) for i,j in zip(device.record,
                                                            range(len(device.record))))
             logger.debug("recording %s from %s" % (variable, self.recorded[variable]))


### PR DESCRIPTION
Fixes an issue where plots of recorded neurons would not match their labels.
This is due to:

ids = set([id for id in ids if id.local])

in PyNN / src / recording / __init__.py, line 197, which in some cases changes the order of neurons, e.g. numpy.fromiter(set(numpy.array([13,14,15,16])) becomes array([16, 13, 14, 15]). Re-sorting the array before sending it to the Brian recording device fixed this for me.