### PR TITLE
nest: Fixed handling of inhibitory weights.

### DIFF
--- a/src/nest/projections.py
+++ b/src/nest/projections.py
@@ -177,6 +177,8 @@ class Projection(common.Projection):
             if connections:
                 source_mask = self.pre.id_to_index([x[0] for x in connections])
                 for name, value in connection_parameters.items():
+                    if name == "weight" and self.receptor_type == 'inhibitory' and self.post.conductance_based:
+                        value *= -1 # NEST uses negative values for inhibitory weights, even if these are conductances
                     value = make_sli_compatible(value)
                     if name not in self._common_synapse_property_names:
                         nest.SetStatus(connections, name, value[source_mask])
@@ -247,6 +249,8 @@ class Projection(common.Projection):
             values = numpy.array(values) # ought to preserve int type for source, target
             scale_factors = numpy.ones(len(names))
             scale_factors[names.index('weight')] = 0.001
+            if self.receptor_type == 'inhibitory' and self.post.conductance_based:
+                scale_factors[names.index('weight')] *= -1 # NEST uses negative values for inhibitory weights, even if these are conductances
             values *= scale_factors
             values = values.tolist()
         if 'presynaptic_index' in names:
@@ -276,7 +280,7 @@ class Projection(common.Projection):
                     value_arr[addr] += value
             if attribute_name == 'weight':
                 value_arr *= 0.001
-                if self.synapse_type == 'inhibitory' and self.post.conductance_based:
+                if self.receptor_type == 'inhibitory' and self.post.conductance_based:
                     value_arr *= -1 # NEST uses negative values for inhibitory weights, even if these are conductances
             all_values.append(value_arr)
         return all_values

--- a/test/unittests/test_nest.py
+++ b/test/unittests/test_nest.py
@@ -97,6 +97,25 @@ class TestProjection(unittest.TestCase):
         prj = sim.Projection(self.p1, self.p2, self.all2all,
                      synapse_type=self.native_synapse_type())
 
+    def test_inhibitory_weight(self):
+        prj = sim.Projection(self.p1, self.p2, self.all2all,
+                synapse_type=self.syn_rnd,
+                receptor_type="inhibitory")
+
+        weights_list = prj.get("weight", format="list")
+        for pre, post, weight in weights_list:
+            self.assertTrue(weight > 0.)
+        weights_array = prj.get("weight", format="array")
+        self.assertTrue((weights_array > 0.).all())
+
+        prj.set(weight=0.456)
+
+        weights_list = prj.get("weight", format="list")
+        for pre, post, weight in weights_list:
+            self.assertTrue(weight > 0.)
+        weights_array = prj.get("weight", format="array")
+        self.assertTrue((weights_array > 0.).all())
+
     def test_create_with_homogeneous_common_properties(self):
         with self.assertRaises(ValueError):
             # create synapse type with heterogeneous common parameters


### PR DESCRIPTION
Nest uses negative weight values internal to designate inhibitory synapses.

Currently, `projection.get("weight", ...)` returns negative weights if the projection is inhibitory. Updating the weights with positive values causes the synapses to become excitatory because the positive values not converted to negative ones before handing them to PyNEST. One has to specify negative weight values when updating inhibitory projection-weights via `projeciton.set(weights=...)`.

This update fixes both issues: Weights from inhibitory projections are returned as positive values and new weights written via `.set` are made negative prior to calling PyNEST.

There is also a unit test validating the behavior.

**Note**: This pull request might conflict with #289 because the line `value = make_sli_compatible(value)` is moved into the if-then-block; the resolution should be obvious.
