### PR TITLE
added grng_seed to the modifiable parameters of NEST via pyNN.nest.setup...

### DIFF
--- a/src/nest/__init__.py
+++ b/src/nest/__init__.py
@@ -95,6 +95,8 @@ def setup(timestep=0.1, min_delay=0.1, max_delay=10.0, **extra_params):
         number of decimal places (OR SIGNIFICANT FIGURES?) in recorded data
     `threads`:
         number of threads to use
+    `grng_seed`:
+        one seed for the global random number generator of NEST
     `rng_seeds`:
         a list of seeds, one for each thread on each MPI process
     `rng_seeds_seed`:
@@ -108,6 +110,8 @@ def setup(timestep=0.1, min_delay=0.1, max_delay=10.0, **extra_params):
             setattr(simulator.state, key, extra_params[key])
     # set kernel RNG seeds
     simulator.state.num_threads = extra_params.get('threads') or 1
+    if 'grng_seed' in extra_params:
+        simulator.state.grng_seed = extra_params['grng_seed']
     if 'rng_seeds' in extra_params:
         simulator.state.rng_seeds = extra_params['rng_seeds']
     else:

--- a/src/nest/simulator.py
+++ b/src/nest/simulator.py
@@ -69,6 +69,8 @@ class _State(common.control.BaseState):
 
     threads = nest_property('local_num_threads', int)
 
+    grng_seed = nest_property('grng_seed', int)
+
     rng_seeds = nest_property('rng_seeds', list)
 
     @property


### PR DESCRIPTION
We added the parameter 'grng_seed' to the list of modifiable parameter of NEST in the pyNN.nest.setup() function, because it is sometimes desirable to control NEST's global random number generator just like the local rngs.
