### PR TITLE
import NEST_SYNAPSE_TYPES from nest.__init__.py

### DIFF
--- a/src/nest/__init__.py
+++ b/src/nest/__init__.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     pass
 import nest
+NEST_SYNAPSE_TYPES = nest.Models(mtype='synapses')
 from . import simulator
 from pyNN import common, recording, errors, space, __doc__
 

--- a/src/nest/standardmodels/synapses.py
+++ b/src/nest/standardmodels/synapses.py
@@ -9,6 +9,7 @@ Synapse Dynamics classes for nest
 import nest
 from pyNN.standardmodels import synapses, build_translations
 from pyNN.nest.synapses import get_synapse_defaults, NESTSynapseMixin
+from pyNN.nest import NEST_SYNAPSE_TYPES
 import logging
 
 logger = logging.getLogger("PyNN")
@@ -48,10 +49,9 @@ class STDPMechanism(synapses.STDPMechanism, NESTSynapseMixin):
             logger.warning(", ".join(model for model in base_model))
             base_model = list(base_model)[0]
             logger.warning("By default, %s is used" % base_model)
-        available_models = nest.Models(mtype='synapses')
-        if base_model not in available_models:
+        if base_model not in NEST_SYNAPSE_TYPES:
             raise ValueError("Synapse dynamics model '%s' not a valid NEST synapse model. "
-                             "Possible models in your NEST build are: %s" % (base_model, available_models))
+                             "Possible models in your NEST build are: %s" % (base_model, NEST_SYNAPSE_TYPES))
 
         # CopyModel defaults must be simple floats, so we use the NEST defaults
         # for any inhomogeneous parameters, and set the inhomogeneous values


### PR DESCRIPTION
The variable NEST_SYNAPSE_TYPES is defined once and then used by pyNN.nest.standardmodels.synapses._get_nest_synapse_model to check for available synapse types in NEST. Before, the function called nest.Models(mtype='synapses') at every function call, which slowed down things a lot, especially in the case of many single projections. 
