### PR TITLE
Nest doesn't accept integer spike_times -> correction proposed

### DIFF
--- a/examples/tsodyksmarkram.py
+++ b/examples/tsodyksmarkram.py
@@ -14,8 +14,7 @@ sim, options = get_simulator()
 
 sim.setup(quit_on_end=False)
 
-source=sim.SpikeSourceArray(spike_times=numpy.arange(10, 100, 10))
-spike_source = sim.Population(1, source)
+spike_source = sim.Population(1, sim.SpikeSourceArray(spike_times=numpy.arange(10, 100, 10)))
 
 connector = sim.AllToAllConnector()
 
@@ -46,6 +45,6 @@ for label,p in populations.items():
                                    "pkl", options.simulator)
     p.write_data(filename, annotations={'script_name': __file__})
 
-print "spike source = ", spike_source.get_data().segments[0].spiketrains
+print spike_source.get_data().segments[0].spiketrains
 
 sim.end()

--- a/src/nest/populations.py
+++ b/src/nest/populations.py
@@ -14,7 +14,6 @@ from pyNN import common, errors
 from pyNN.parameters import Sequence, ParameterSpace, simplify
 from pyNN.random import RandomDistribution
 from pyNN.standardmodels import StandardCellType
-from pyNN.standardmodels.cells import SpikeSourceArray
 from . import simulator
 from .recording import Recorder, VARIABLE_MAP
 from .conversion import make_sli_compatible
@@ -120,6 +119,7 @@ class Population(common.Population, PopulationMixin):
                                    None,
                                    size=self.size)
         try:
+	    #hack: force the spike_times array to be float, and not int
 	    if params and hasattr(params, '__iter__') and 'spike_times' in params and params['spike_times'].dtype == int:
 		params['spike_times'] = params['spike_times'].astype(float)
             self.all_cells = nest.Create(nest_model, self.size, params=params)


### PR DESCRIPTION
Running the example tsodyksmarkram.py with nest gives an error:

> cd examples
> python tsodyksmarkram.py nest
> There is no error if the line:
> spike_source = sim.Population(1, sim.SpikeSourceArray(spike_times=numpy.arange(10, 100, 10)))
> is replaced by:
> spike_source = sim.Population(1, sim.SpikeSourceArray(spike_times=numpy.arange(10., 100., 10.)))

that is if the numpy array passed to spike_times is float, and not int.
The other backends (neuron and brian) seem to accept the int (at least, they don't give any error). I propose a small change in nest/populations.py that transforms the int array into a float array
