### PR TITLE
Add optimized CSAConnector iterating connection-sets in NEST

### DIFF
--- a/src/nest/connectors.py
+++ b/src/nest/connectors.py
@@ -30,43 +30,60 @@ try:
 except ImportError:
     haveCSA = False
 
-class CSAConnector(Connector):
-    """
-    Use the Connection Set Algebra (Djurfeldt, 2012) to connect cells.
 
-    Takes any of the standard :class:`Connector` optional arguments and, in
-    addition:
+if not nest.sli_func("statusdict/have_libneurosim ::"):
 
-        `cset`:
-            a connection set object.
-    """
-    parameter_names = ('cset',)
+    print ("CSAConnector: libneurosim support not available in NEST.\n" +
+           "Falling back on PyNN's default CSAConnector.\n" +
+           "Please re-compile NEST using --with-libneurosim=PATH")
 
-    if haveCSA:
-        def __init__ (self, cset, safe=True, callback=None):
-            """
-            """
-            Connector.__init__(self, safe=safe, callback=callback)
-            self.cset = cset
-            arity = csa.arity(cset)
-            assert arity in (0, 2), 'must specify mask or connection-set with arity 0 or 2'
-    else:
-        def __init__ (self, cset, safe=True, callback=None):
-            raise RuntimeError, "CSAConnector not available---couldn't import csa module"
+    from pyNN.connectors import CSAConnector
 
-    def connect(self, projection):
-        """Connect-up a Projection."""
+else:
 
-        presynaptic_cells = projection.pre.all_cells.astype('int64')
-        postsynaptic_cells = projection.post.all_cells.astype('int64')
+    class CSAConnector(Connector):
+        """
+        Use the Connection-Set Algebra (Djurfeldt, 2012) to connect
+        cells. This is an optimized variant of CSAConnector, which
+        iterates the connection-set on the C++ level in NEST.
 
-        if csa.arity(self.cset) == 2:
-            param_map = {'weight': 0, 'delay': 1}
-            nest.CGConnect(presynaptic_cells, postsynaptic_cells, self.cset,
-                           param_map, projection.nest_synapse_model)
+        See Djurfeldt et al. (2014) doi:10.3389/fninf.2014.00043 for
+	more details about the new interface and a comparison between
+	this and PyNN's native CSAConnector.
+    
+        Takes any of the standard :class:`Connector` optional
+        arguments and, in addition:
+    
+            `cset`:
+                a connection set object.
+        """
+        parameter_names = ('cset',)
+    
+        if haveCSA:
+            def __init__ (self, cset, safe=True, callback=None):
+                """
+                """
+                Connector.__init__(self, safe=safe, callback=callback)
+                self.cset = cset
+                arity = csa.arity(cset)
+                assert arity in (0, 2), 'must specify mask or connection-set with arity 0 or 2'
         else:
-            nest.CGConnect(presynaptic_cells, postsynaptic_cells, self.cset,
-                           model=projection.nest_synapse_model)
-
-        projection._connections = None  # reset the caching of the connection list, since this will have to be recalculated
-        projection._sources.extend(presynaptic_cells)
+            def __init__ (self, cset, safe=True, callback=None):
+                raise RuntimeError, "CSAConnector not available---couldn't import csa module"
+    
+        def connect(self, projection):
+            """Connect-up a Projection."""
+    
+            presynaptic_cells = projection.pre.all_cells.astype('int64')
+            postsynaptic_cells = projection.post.all_cells.astype('int64')
+    
+            if csa.arity(self.cset) == 2:
+                param_map = {'weight': 0, 'delay': 1}
+                nest.CGConnect(presynaptic_cells, postsynaptic_cells, self.cset,
+                               param_map, projection.nest_synapse_model)
+            else:
+                nest.CGConnect(presynaptic_cells, postsynaptic_cells, self.cset,
+                               model=projection.nest_synapse_model)
+    
+            projection._connections = None  # reset the caching of the connection list, since this will have to be recalculated
+            projection._sources.extend(presynaptic_cells)


### PR DESCRIPTION
These changes implement an optimized CSAConnector for the NEST backend that uses the CGConnect function of PyNEST to iterate connection-sets in NEST on the C++ level instead in PyNN on the Python level. The details are described in Djurfeldt et al. (2014) doi:10.3389/fninf.2014.00043.
