### PR TITLE
NEST 2.4 compatibility

### DIFF
--- a/src/nest/cells.py
+++ b/src/nest/cells.py
@@ -21,7 +21,7 @@ def get_defaults(model_name):
               'frozen', 'instantiations', 'local', 'model', 'recordables',
               'state', 't_spike', 'tau_minus', 'tau_minus_triplet',
               'thread', 'vp', 'receptor_types', 'events', 'global_id',
-              'type', 'type_id']
+              'node_type', 'type', 'type_id']
     default_params = {}
     default_initial_values = {}
     for name,value in defaults.items():

--- a/src/nest/synapses.py
+++ b/src/nest/synapses.py
@@ -20,7 +20,7 @@ def get_synapse_defaults(model_name):
     defaults = nest.GetDefaults(model_name)
     ignore = ['max_delay', 'min_delay', 'num_connections',
               'num_connectors', 'receptor_type', 'synapsemodel',
-              'property_object', 'type']
+              'property_object', 'node_type', 'type']
     default_params = {}
     for name,value in defaults.items():
         if name not in ignore:


### PR DESCRIPTION
In NEST 2.4 the 'type' got renamed to 'node_type', which caused it to be included in the default parameters of native models. This pull request fixes that.
For backwards compatibility to NEST 2.2.2 both 'type' and 'node_type' are ignored for now.
