### PR TITLE
implemented transformation of parameters for random distributions specif...

### DIFF
--- a/src/nest/connectors.py
+++ b/src/nest/connectors.py
@@ -29,7 +29,7 @@ from pyNN.connectors import Connector, \
                             CloneConnector, \
                             ArrayConnector
 
-from .random import NativeRNG, NEST_RDEV_TYPES
+from .random import NativeRNG, NEST_RDEV_TYPES, NEST_RDIST_TRANSFORMATIONS
 
 
 logger = logging.getLogger("PyNN")
@@ -104,7 +104,16 @@ class NESTConnectorMixin(object):
             if isinstance(value.base_value, random.RandomDistribution):     # Random Distribution specified
                 if value.base_value.name in NEST_RDEV_TYPES:
                     logger.warning("Random values will be created inside NEST with NEST's own RNGs")
-                    params[name] = NativeRNG(value.base_value).parameters
+                    dist_params = {}
+                    ### Transform distribution parameters to nest-specific units
+                    rng = NativeRNG(value.base_value)
+                    for name in rng.parameters.keys() :
+                        if name =='distribution' or name != 'weight' :
+                            pval = rng.parameters[name]
+                        else :
+                            pval = eval(NEST_RDIST_TRANSFORMATIONS[value.base_value.name][name],rng.parameters)
+                        dist_params[name] = pval
+                    params[name] = dist_params
                 else:
                     value.shape = (projection.pre.size, projection.post.size)
                     params[name] = value.evaluate()

--- a/src/nest/random.py
+++ b/src/nest/random.py
@@ -4,6 +4,17 @@ NEST_RDEV_TYPES = ['binomial', 'binomial_clipped', 'binomial_clipped_to_boundary
                    'poisson', 'poisson_clipped', 'poisson_clipped_to_boundary',
                    'uniform', 'uniform_int']
 
+NEST_RDIST_TRANSFORMATIONS = {'normal' : {'mu' : 'mu*1000', 'sigma' : 'sigma*1000'},
+                         'normal_clipped' : {'mu' : 'mu*1000', 'sigma' : 'sigma*1000', 'high' : 'high', 'low' : 'low'},
+                         'normal_clipped_to_boundary' : {'mu' : 'mu*1000', 'sigma' : 'sigma*1000', 'high' : 'high', 'low' : 'low'},
+                         'uniform' : {'low' : 'low*1000', 'high' : 'high*1000'},
+                         'gamma' : {'order' : 'order', 'scale' : 'scale*1000'},
+                         'gamma_clipped' : {'order' : 'order', 'scale' : 'scale*1000', 'high' : 'high', 'low' : 'low'},
+                         'gamma_clipped_to_boundary' : {'order' : 'order', 'scale' : 'scale*1000', 'high' : 'high', 'low' : 'low'},
+                         'lognormal' : {'mu' : "mu+__import__('numpy').log(1000.)", 'sigma' : 'sigma'},
+                         'lognormal_clipped' : {'mu' : "mu+__import__('numpy').log(1000.)", 'sigma' : 'sigma', 'high' : 'high', 'low' : 'low'},
+                         'lognormal_clipped_to_boundary' : {'mu' : "mu+__import__('numpy').log(1000.)", 'sigma' : 'sigma', 'high' : 'high', 'low' : 'low'}}
+
 
 class NativeRNG():
     """


### PR DESCRIPTION
...ying synaptic weights.

NEST describes synaptic currents in pA while pyNN uses nA.
When random distributions for weights are chosen, the pyNN.nest backend now forwards the drawing of the random number to NEST with its internally implemented distributions. Therefore, the parameters of the given distribution have to be tranformed so that the distribution is correctly transformed.

This branch implements the parameter transformations for which the transformation is possible. It is not possible for binomial and poisson distribution for mathematical reasons.
