### PR TITLE
[Nest] Fixed receptor type mismatch in native cell types

### DIFF
--- a/src/nest/cells.py
+++ b/src/nest/cells.py
@@ -57,7 +57,7 @@ def native_cell_type(model_name):
                  'injectable': ("V_m" in default_initial_values),
                  'recordable': recordable,
                  'units': dict(((var, UNITS_MAP.get(var, 'unknown')) for var in recordable)),
-                 'standard_receptor_type': (receptor_types == ('excitatory', 'inhibitory')),
+                 'standard_receptor_type': (receptor_types == ['excitatory', 'inhibitory']),
                  'nest_name': {"on_grid": model_name, "off_grid": model_name},
                  'conductance_based': ("g" in (s[0] for s in recordable)),
                  })


### PR DESCRIPTION
In `src/nest/cells.py`, `get_receptor_types` was changed to return a list
instead of a tuple, but `native_cell_type` still compared the returned receptor
types to the old tuple which lead to `standard_receptor_type`-attribute to be
wrongly set to `False`.

This caused problems when creating Projections, for instance, to parrot neurons.
