### PR TITLE
Change NEST 'node_type' to 'element_type'

### DIFF
--- a/src/nest/cells.py
+++ b/src/nest/cells.py
@@ -25,7 +25,7 @@ def get_defaults(model_name):
               'frozen', 'instantiations', 'local', 'model', 'recordables',
               'state', 't_spike', 'tau_minus', 'tau_minus_triplet',
               'thread', 'vp', 'receptor_types', 'events', 'global_id',
-              'node_type', 'type', 'type_id', 'has_connections', 'n_synapses']
+              'element_type', 'type', 'type_id', 'has_connections', 'n_synapses']
     default_params = {}
     default_initial_values = {}
     for name, value in defaults.items():

--- a/src/nest/synapses.py
+++ b/src/nest/synapses.py
@@ -20,7 +20,7 @@ def get_synapse_defaults(model_name):
     defaults = nest.GetDefaults(model_name)
     ignore = ['max_delay', 'min_delay', 'num_connections',
               'num_connectors', 'receptor_type', 'synapsemodel',
-              'property_object', 'node_type', 'type']
+              'property_object', 'element_type', 'type']
     default_params = {}
     for name, value in defaults.items():
         if name not in ignore:


### PR DESCRIPTION
In the next NEST release, the internal parameter name 'node_type' will changed to 'element_type'. With this commit the change is reflected in PyNN.