### PR TITLE
Rename the parameter "lambda" of the Poisson distribution to "lambda_"

### DIFF
--- a/doc/connections.txt
+++ b/doc/connections.txt
@@ -247,7 +247,7 @@ The :class:`FixedNumberPreConnector` has the same arguments as
 .. testcode::
 
     connector = FixedNumberPreConnector(5)
-    distr_npre = RandomDistribution(distribution='poisson', lambda=5)
+    distr_npre = RandomDistribution(distribution='poisson', lambda_=5)
     connector = FixedNumberPreConnector(distr_npre)
 
 

--- a/src/nest/random.py
+++ b/src/nest/random.py
@@ -30,7 +30,7 @@ class NativeRNG(NativeRNG):
         'normal_clipped': {'mu': 'mu', 'sigma': 'sigma', 'low': 'low', 'high': 'high'},
         'normal_clipped_to_boundary':
                           {'mu': 'mu', 'sigma': 'sigma', 'low': 'low', 'high': 'high'},
-        'poisson':        {'lambda': 'lambda'},
+        'poisson':        {'lambda_': 'lambda'},
         'uniform':        {'low': 'low', 'high': 'high'},
         'uniform_int':    {'low': 'low', 'high': 'high'},
         'vonmises':       {'mu': 'mu', 'kappa': 'kappa'},

--- a/src/neuron/random.py
+++ b/src/neuron/random.py
@@ -27,7 +27,7 @@ class NativeRNG(NativeRNG, WrappedRNG):
         #'normal_clipped': ('normal_clipped', {'mu': 'mu', 'sigma': 'sigma', 'low': 'low', 'high': 'high'}),
         #'normal_clipped_to_boundary':
         #                  ('normal_clipped_to_boundary', {'mu': 'mu', 'sigma': 'sigma', 'low': 'low', 'high': 'high'}),
-        'poisson':        ('poisson',      ('lambda',)),
+        'poisson':        ('poisson',      ('lambda_',)),
         'uniform':        ('uniform',      ('low', 'high')),
         'uniform_int':    ('discunif',     ('low', 'high')),
         #'vonmises':       ('vonmises',     {'mu': 'mu', 'kappa': 'kappa'}),

--- a/src/random.py
+++ b/src/random.py
@@ -40,7 +40,7 @@ available_distributions = {
     'normal_clipped': ('mu', 'sigma', 'low', 'high'),
     'normal_clipped_to_boundary':
                       ('mu', 'sigma', 'low', 'high'),
-    'poisson':        ('lambda',),
+    'poisson':        ('lambda_',),
     'uniform':        ('low', 'high'),
     'uniform_int':    ('low', 'high'),
     'vonmises':       ('mu', 'kappa'),
@@ -176,7 +176,7 @@ class NumpyRNG(WrappedRNG):
         'normal_clipped': ('normal_clipped', {'mu': 'mu', 'sigma': 'sigma', 'low': 'low', 'high': 'high'}),
         'normal_clipped_to_boundary':
                           ('normal_clipped_to_boundary', {'mu': 'mu', 'sigma': 'sigma', 'low': 'low', 'high': 'high'}),
-        'poisson':        ('poisson',      {'lambda': 'lam'}),
+        'poisson':        ('poisson',      {'lambda_': 'lam'}),
         'uniform':        ('uniform',      {'low': 'low', 'high': 'high'}),
         'uniform_int':    ('randint',      {'low': 'low', 'high': 'high'}),
         'vonmises':       ('vonmises',     {'mu': 'mu', 'kappa': 'kappa'}),
@@ -240,7 +240,7 @@ class GSLRNG(WrappedRNG):
         'lognormal':      ('lognormal',      {'mu': 'zeta', 'sigma': 'sigma'}),
         'normal':         ('normal',         {'mu': 'mu', 'sigma': 'sigma'}),
         'normal_clipped': ('normal_clipped', {'mu': 'mu', 'sigma': 'sigma', 'low': 'low', 'high': 'high'}),
-        'poisson':        ('poisson',        {'lambda': 'mu'}),
+        'poisson':        ('poisson',        {'lambda_': 'mu'}),
         'uniform':        ('flat',           {'low': 'a', 'high': 'b'}),
         'uniform_int':    ('uniform_int',    {'low': 'low', 'high': 'high'}),
     }
@@ -337,9 +337,9 @@ class RandomDistribution(VectorizedIterable):
 
     Available distributions:
 
-    ==========================  ====================  ===============================================
+    ==========================  ====================  ====================================================
     Name                        Parameters            Comments
-    --------------------------  --------------------  -----------------------------------------------
+    --------------------------  --------------------  ----------------------------------------------------
     binomial                    n, p
     gamma                       k, theta
     exponential                 beta
@@ -347,11 +347,11 @@ class RandomDistribution(VectorizedIterable):
     normal                      mu, sigma
     normal_clipped              mu, sigma, low, high  Values outside (low, high) are redrawn
     normal_clipped_to_boundary  mu, sigma, low, high  Values below/above low/high are set to low/high
-    poisson                     lambda
+    poisson                     lambda_               Trailing underscore since lambda is a Python keyword
     uniform                     low, high
     uniform_int                 low, high
     vonmises                    mu, kappa
-    ==========================  ====================  ===============================================
+    ==========================  ====================  ====================================================
     """
 
     def __init__(self, distribution, parameters_pos=None, rng=None, **parameters_named):


### PR DESCRIPTION
...to avoid clashing with Python keyword lambda.

(The original idea was to require `RandomDistribution("poisson", **{"lambda": 5})` but on reflection triggered by #347 this is a terrible idea).