### PR TITLE
Fixed exception message when a parameter fails a type validation check.

### DIFF
--- a/src/parameters.py
+++ b/src/parameters.py
@@ -269,7 +269,7 @@ class ParameterSpace(object):
                     self._parameters[name] = LazyArray(value, shape=self._shape,
                                                        dtype=expected_dtype)
                 except (TypeError, errors.InvalidParameterValueError):
-                    raise errors.InvalidParameterValueError("For parameter %s expected %s, got %s" % (name, type(value), expected_dtype))
+                    raise errors.InvalidParameterValueError("For parameter %s expected %s, got %s" % (name, expected_dtype, type(value)))
                 except ValueError as err:
                     raise errors.InvalidDimensionsError(err) # maybe put the more specific error classes into lazyarray
         else:


### PR DESCRIPTION
In the exception message, the "got" and "expected" types were backwards. Super minor bug, I know, but hopefully this'll save someone an hour of confusion!