### PR TITLE
switched solve method of Izhikevich NMODL from cnexp to derivimplicit

### DIFF
--- a/src/neuron/nmodl/izhikevich.mod
+++ b/src/neuron/nmodl/izhikevich.mod
@@ -42,7 +42,7 @@ STATE {
 }
 
 BREAKPOINT {
-    SOLVE states METHOD cnexp  : derivimplicit
+    SOLVE states METHOD derivimplicit
     i = -Cm * (0.04*v*v + 5*v + 140 - u)
     :printf("t=%f, v=%f u=%f, i=%f, dv=%f, du=%f\n", t, v, u, i, 0.04*v*v + 5*v + 140 - u, a*(b*v-u))
 }


### PR DESCRIPTION
According to Michael's response to this bug I filed on the NEURON forum, https://www.neuron.yale.edu/phpBB/viewtopic.php?f=16&t=3278, the solve method for the Izhikevich.mod file should be `derivimplicit` not `cnexp` (which is only meant to be used for single state variable equations)

> The cnexp method is invalid for that derivative equation.
The cnexp method requires that each y' equation be linear and involve no other state than y.
That is, cnexp was intended for use only in HH style gating equations where the form looked like
m' = (minf(v) - m)/mtau(v)
or
m' = bm(v)*(1. - m) - am(v)*m

> For general (nonlinear and coupled state ) equations, use derivimplicit. I need to change the nmodl translator to generate an error message if the equation forms do not
satisfy the cnexp requirements and will look into the possibility of doing that.
I don't think "Rounding error" is a good set of keywords for this topic. Perhaps nonsense numerical results would be better.
I should mention that even derivimplicit will not result in a simulation that uses the full jacobian in this case but only the diagonal terms dv'/dv and du'/du . That is usually sufficient for numerical stability in most practical circumstances.

I noticed that the `derivimplicit` method had been commented out so I am not sure if there was some deliberate reason behind the change, but it seems as though `cnexp` is not a good choice.