### PR TITLE
This Pull Request fixes #385

### DIFF
--- a/pyNN/nest/simulator.py
+++ b/pyNN/nest/simulator.py
@@ -89,9 +89,10 @@ class _State(common.control.BaseState):
             min_delay = float(min_delay)
             max_delay = float(max_delay)
             for synapse_model in nest.Models(mtype='synapses'):
-                nest.SetDefaults(synapse_model, {'delay': min_delay,
-                                                 'min_delay': min_delay,
-                                                 'max_delay': max_delay})
+                if synapse_model != 'gap_junction':
+                    nest.SetDefaults(synapse_model, {'delay': min_delay,
+                                                     'min_delay': min_delay,
+                                                     'max_delay': max_delay})
 
     @property
     def max_delay(self):


### PR DESCRIPTION
The delay can't be set for a `gap_junction`, since this synapse model has no delay.
