### PR TITLE
Fix min delay error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
   - 3.3
   - 3.5
   - "2.7_with_system_site_packages"
-sudo: false
+sudo: required
+dist: trusty
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
       - python-sympy
       - openmpi-bin
       - libopenmpi-dev
+      - cmake
 install:
   - pip install -r requirements.txt
   - pip install coverage coveralls

--- a/ci/install_nest.sh
+++ b/ci/install_nest.sh
@@ -2,33 +2,20 @@
 
 set -e  # stop execution in case of errors
 
-if [[ "$TRAVIS_PYTHON_VERSION" == "2.7_with_system_site_packages" ]]; then
-
-    export NEST_VERSION="2.10.0"
-    export NEST="nest-$NEST_VERSION"
+    export NEST_VERSION="master"
+    export NEST="nest-simulator-$NEST_VERSION"
     pip install cython
-    if [ ! -f "$HOME/$NEST_VERSION/configure" ]; then
-        wget https://github.com/nest/nest-simulator/releases/download/v$NEST_VERSION/$NEST.tar.gz -O $HOME/$NEST.tar.gz;
-        pushd $HOME;
-        tar xzf $NEST.tar.gz;
-        popd;
-    else
-        echo 'Using cached version of NEST sources.';
-    fi
+    wget https://github.com/nest/nest-simulator/archive/$NEST_VERSION.tar.gz -O $HOME/$NEST.tar.gz;
+    pushd $HOME;
+    tar xzf $NEST.tar.gz;
+    popd;
+
     mkdir -p $HOME/build/$NEST
     pushd $HOME/build/$NEST
-    if [ ! -f "$HOME/build/$NEST/config.log" ]; then
-        export VENV=`python -c "import sys; print sys.prefix"`;
-        $HOME/$NEST/configure --with-mpi --prefix=$VENV;
-        make;
-    else
-        echo 'Using cached NEST build directory.';
-        echo "$HOME/$NEST";
-        ls $HOME/$NEST;
-        echo "$HOME/build/$NEST";
-        ls $HOME/build/$NEST;
-    fi
+    export VENV=`python -c "import sys; print sys.prefix"`;
+    echo $VENV
+    echo $PWD
+    cmake -DCMAKE_INSTALL_PREFIX=$VENV -Dwith-mpi=ON $HOME/$NEST;
+    make;
     make install
     popd
-
-fi

--- a/pyNN/nest/simulator.py
+++ b/pyNN/nest/simulator.py
@@ -79,23 +79,14 @@ class _State(common.control.BaseState):
 
     @property
     def min_delay(self):
-        # this rather complex implementation is needed to handle min_delay='auto'
-        kernel_delay = nest.GetKernelStatus('min_delay')
-        syn_delay = nest.GetDefaults('static_synapse')['min_delay']
-        if syn_delay == numpy.inf or syn_delay > 1e300:
-            return kernel_delay
-        else:
-            return max(kernel_delay, syn_delay)
+        return nest.GetKernelStatus('min_delay')
 
     def set_delays(self, min_delay, max_delay):
-        if min_delay != 'auto': 
+        if min_delay != 'auto':
             min_delay = float(min_delay)
             max_delay = float(max_delay)
-            for synapse_model in nest.Models(mtype='synapses'):
-                if synapse_model not in ['gap_junction', 'gap_junction_lbl']:
-                    nest.SetDefaults(synapse_model, {'delay': min_delay,
-                                                     'min_delay': min_delay,
-                                                     'max_delay': max_delay})
+            nest.SetKernelStatus({'min_delay': min_delay,
+                                  'max_delay': max_delay})
 
     @property
     def max_delay(self):


### PR DESCRIPTION
This PR supersedes #413 .

In NEST, min_delay is no longer set in the defaults of each synapse but min_delay is set globally in the NEST kernel.
This fixes #411 .

In addition, the install_nest.sh script for Travis was changed to download and build the current master from [https://github.com/nest/nest-simulator](https://github.com/nest/nest-simulator). To achieve this, I removed the possibility to fall back on cached code so that Travis always checks with the current master branch of NEST.
