### PR TITLE
Remove old connect routines

### DIFF
--- a/pyNN/nest/recording.py
+++ b/pyNN/nest/recording.py
@@ -76,7 +76,6 @@ class RecordingDevice(object):
 
 class SpikeDetector(RecordingDevice):
     """A wrapper around the NEST spike_detector device"""
-    _nest_connect = lambda device, ids: nest.ConvergentConnect()
 
     def __init__(self, to_memory=True):
         self.device = nest.Create('spike_detector')
@@ -111,7 +110,6 @@ class SpikeDetector(RecordingDevice):
 
 class Multimeter(RecordingDevice):
     """A wrapper around the NEST multimeter device"""
-    _nest_connect = nest.ConvergentConnect
 
     def __init__(self, to_memory=True):
         self.device = nest.Create('multimeter')

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -43,7 +43,7 @@ class NestCurrentSource(StandardCurrentSource):
             self.cell_list = [cell for cell in cells]
         else:
             self.cell_list = cells
-        nest.DivergentConnect(self._device, self.cell_list)
+        nest.Connect(self._device, self.cell_list)
 
     def _delay_correction(self, value):
         return value - state.min_delay


### PR DESCRIPTION
This PR removes the last usages of the deprecated NEST connection routines `DivergentConnect` and `ConvergentConnect`. It fixes #414 .

This works with NEST 2.10., therefore I request to merge into master.