### PR TITLE
Added `SpikeSourceGamma` model.

### DIFF
--- a/pyNN/nest/populations.py
+++ b/pyNN/nest/populations.py
@@ -68,6 +68,8 @@ def _build_params(parameter_space, mask_local, size=None, extra_parameters=None)
     Return either a single parameter dict or a list of dicts, suitable for use
     in Create or SetStatus.
     """
+    if "UNSUPPORTED" in parameter_space.keys():
+        parameter_space.pop("UNSUPPORTED")
     if size:
         parameter_space.shape = (size,)
     if parameter_space.is_homogeneous:

--- a/pyNN/nest/standardmodels/cells.py
+++ b/pyNN/nest/standardmodels/cells.py
@@ -216,6 +216,33 @@ class SpikeSourcePoisson(cells.SpikeSourcePoisson):
     }
 
 
+def unsupported(parameter_name, valid_value):
+    def error_if_invalid(**parameters):
+        if parameters[parameter_name].base_value != valid_value:
+            raise NotImplementedError("The `{}` parameter is not supported in NEST".format(parameter_name))
+        return valid_value
+    return error_if_invalid
+
+
+class SpikeSourceGamma(cells.SpikeSourceGamma):
+
+    __doc__ = cells.SpikeSourceGamma.__doc__
+
+    translations = build_translations(
+        ('alpha',    'gamma_shape'),
+        ('beta',     'rate',        'beta/alpha',   'gamma_shape * rate'),
+        ('start',    'UNSUPPORTED', unsupported('start', 0.0), None),
+        ('duration', 'UNSUPPORTED', unsupported('duration', 1e10), None),
+    )
+    nest_name = {"on_grid": 'gamma_sup_generator',
+                 "off_grid": 'gamma_sup_generator'}
+    always_local = True
+    uses_parrot = True
+    extra_parameters = {
+        'n_proc': 1
+    }
+
+
 class SpikeSourceInhGamma(cells.SpikeSourceInhGamma):
     
     __doc__ = cells.SpikeSourceInhGamma.__doc__ 

--- a/pyNN/neuron/cells.py
+++ b/pyNN/neuron/cells.py
@@ -447,6 +447,23 @@ class RandomSpikeSource(hclass(h.NetStimFD)):
     _interval = property(fget=_get_interval, fset=_set_interval)
 
 
+class RandomGammaSpikeSource(hclass(h.GammaStim)):
+
+    parameter_names = ('alpha', 'beta', 'start', 'duration')
+
+    def __init__(self, alpha=1, beta=0.1, start=0, duration=0):
+        self.alpha = alpha
+        self.beta = beta
+        self.start = start
+        self.duration = duration
+        self.spike_times = h.Vector(0)
+        self.source = self
+        self.rec = h.NetCon(self, None)
+        self.switch = h.NetCon(None, self)
+        self.source_section = None
+        self.seed(state.mpi_rank + state.native_rng_baseseed)
+
+
 class VectorSpikeSource(hclass(h.VecStim)):
 
     parameter_names = ('spike_times',)

--- a/pyNN/neuron/nmodl/gammastim.mod
+++ b/pyNN/neuron/nmodl/gammastim.mod
@@ -1,0 +1,98 @@
+COMMENT
+
+Spike generator following a gamma process.
+
+Gamma distributed random variables are generated using the Marsaglia-Tang method:
+
+  G. Marsaglia and W. Tsang (2000) A simple method for generating gamma variables.
+  ACM Transactions on Mathematical Software, 26(3):363-372. doi:10.1145/358407.358414
+
+Parameters:
+    alpha:     shape parameter of the gamma distribution. 1 = Poisson process.
+    beta:      rate parameter of gamma distribution (/ms). Note that the mean interval is alpha/beta
+    start:     start of gamma process (ms)
+    duration:  length in ms of the spike train.
+
+Author: Andrew P. Davison, UNIC, CNRS
+
+ENDCOMMENT
+
+NEURON  {
+    ARTIFICIAL_CELL GammaStim
+    RANGE alpha, beta, start, duration
+}
+
+PARAMETER {
+    alpha = 1                     : shape parameter of gamma distribution. 1 = Poisson process.
+    beta = 0.1 (/ms) <1e-9,1e9>   : rate parameter of gamma distribution
+                                  : mean interval is alpha/beta
+    start = 1 (ms)                : start of first spike
+    duration = 1000 (ms)          : input duration
+}
+
+ASSIGNED {
+    event (ms)
+    on
+    end (ms)
+}
+
+PROCEDURE seed(x) {
+    set_seed(x)
+}
+
+INITIAL {
+    on = 0
+    if (start >= 0) {
+        net_send(event, 2)
+    }
+}
+
+PROCEDURE event_time() {
+    event = event + rand_gamma(alpha, beta)
+    if (event > end) {
+        on = 0
+    }
+}
+
+NET_RECEIVE (w) {
+    if (flag == 2) { : from INITIAL
+        if (on == 0) {
+            on = 1
+            event = t
+            end = t + 1e-6 + duration
+            net_send(0, 1)
+        }
+    }
+    if (flag == 1 && on == 1) {
+        net_event(t)
+        event = event + rand_gamma(alpha, beta)
+        if (event > end) {
+            on = 0
+        }
+        if (on == 1) {
+            net_send(event - t, 1)
+        }
+    }
+}
+
+FUNCTION rand_gamma(a(1), b(/ms)) (1) {
+    LOCAL c, d, Z, U, V
+
+    if (a > 1) {
+        d = alpha - 1/3
+        c = 1/sqrt(9*d)
+        Z = normrand(0, 1)
+        U = scop_random()
+        V = (1 + c*Z)^3
+        while ((Z < -1/c) || (log(U) > 0.5*Z*Z + d - d*V + d*log(V))) {
+            Z = normrand(0, 1)
+            U = scop_random()
+            V = (1 + c*Z)^3
+        }
+        rand_gamma = d * V / b
+    } else {
+        U = scop_random()
+        rand_gamma = rand_gamma(a + 1, b) * U^(1/alpha)
+    }
+
+}

--- a/pyNN/neuron/standardmodels/cells.py
+++ b/pyNN/neuron/standardmodels/cells.py
@@ -10,6 +10,7 @@ Standard base_cells for the neuron module.
 from pyNN.standardmodels import cells as base_cells, build_translations
 from pyNN.neuron.cells import (StandardIF, SingleCompartmentTraub,
                                RandomSpikeSource, VectorSpikeSource,
+                               RandomGammaSpikeSource,
                                BretteGerstnerIF, GsfaGrrIF, Izhikevich_)
 import logging
 
@@ -184,6 +185,18 @@ class SpikeSourcePoisson(base_cells.SpikeSourcePoisson):
         ('duration', 'duration'),
     )
     model = RandomSpikeSource
+
+
+class SpikeSourceGamma(base_cells.SpikeSourceGamma):
+    __doc__ = base_cells.SpikeSourceGamma.__doc__
+
+    translations = build_translations(
+        ('alpha',    'alpha'),
+        ('beta',     'beta',    0.001),
+        ('start',    'start'),
+        ('duration', 'duration'),
+    )
+    model = RandomGammaSpikeSource
 
 
 class SpikeSourceArray(base_cells.SpikeSourceArray):

--- a/pyNN/standardmodels/cells.py
+++ b/pyNN/standardmodels/cells.py
@@ -413,6 +413,23 @@ class SpikeSourcePoisson(StandardCellType):
     receptor_types = ()
 
 
+class SpikeSourceGamma(StandardCellType):
+    """Spike source, generating spikes according to a gamma process.
+
+    The mean inter-spike interval is given by alpha/beta
+    """
+
+    default_parameters = {
+        'alpha':       2,  # shape (order) parameter of the gamma distribution
+        'beta':      1.0,  # rate parameter of the gamma distribution (Hz)
+        'start':     0.0,  # Start time (ms)
+        'duration': 1e10,  # Duration of spike sequence (ms)
+    }
+    recordable = ['spikes']
+    injectable = False
+    receptor_types = ()
+
+
 class SpikeSourceInhGamma(StandardCellType):
     """
     Spike source, generating realizations of an inhomogeneous gamma process,


### PR DESCRIPTION
with implementations in NEST and NEURON backends, and unit test. cf #386 

**NEST**
![test_spikesourcegamma_pynn nest](https://cloud.githubusercontent.com/assets/260552/20156771/1a83cfe0-a6d2-11e6-8076-684ba29e8e42.png)

**NEURON**
![test_spikesourcegamma_pynn neuron](https://cloud.githubusercontent.com/assets/260552/20156772/1ac4f2f4-a6d2-11e6-9367-3fb7de9118ec.png)

Note that the distribution for NEST is slightly distorted for high rates, since spikes can only occur on time-step boundaries.