### PR TITLE
Added a `multiple_synapses` flag to `Projection.get(..., format="array")`

### DIFF
--- a/doc/reference/connectors.txt
+++ b/doc/reference/connectors.txt
@@ -30,10 +30,16 @@ Built-in connectors
 
 .. autoclass:: FixedNumberPostConnector
 
+.. autoclass:: FixedTotalNumberConnector
+
 .. autoclass:: DistanceDependentProbabilityConnector
 
 .. autoclass:: IndexBasedProbabilityConnector
 
+.. autoclass:: DisplacementDependentProbabilityConnector
+
 .. autoclass:: SmallWorldConnector
 
 .. autoclass:: CSAConnector
+
+.. autoclass:: CloneConnector

--- a/pyNN/brian/projections.py
+++ b/pyNN/brian/projections.py
@@ -193,12 +193,12 @@ class Projection(common.Projection):
             filtered_value = value[syn_obj.postsynaptic, syn_obj.presynaptic]
             setattr(syn_obj, name, filtered_value)
     
-    def _get_attributes_as_arrays(self, *attribute_names):
+    def _get_attributes_as_arrays(self, attribute_names, multiple_synapses='sum'):
         if isinstance(self.post, common.Assembly) or isinstance(self.pre, common.Assembly):
             raise NotImplementedError
         values = []
         for name in attribute_names:
-            value = getattr(self._brian_synapses[0][0], name).to_matrix(multiple_synapses='sum')
+            value = getattr(self._brian_synapses[0][0], name).to_matrix(multiple_synapses=multiple_synapses)
             if name == 'delay':
                 value *= self._simulator.state.dt * ms
             ps = self.synapse_type.reverse_translate(ParameterSpace({name: value}, shape=value.shape))  # should really use the translated name
@@ -208,7 +208,7 @@ class Projection(common.Projection):
         # todo: implement parameter translation
         return values  # should put NaN where there is no connection?
 
-    def _get_attributes_as_list(self, *attribute_names):
+    def _get_attributes_as_list(self, attribute_names):
         if isinstance(self.post, common.Assembly) or isinstance(self.pre, common.Assembly):
             raise NotImplementedError
         values = []

--- a/pyNN/common/projections.py
+++ b/pyNN/common/projections.py
@@ -58,6 +58,13 @@ class Projection(object):
             TO DOCUMENT
     """
     _nProj = 0
+    MULTI_SYNAPSE_OPERATIONS = {
+        'last': lambda a, b: b,
+        'first': lambda a, b: a,
+        'sum': operator.iadd,
+        'min': min,
+        'max': max
+    }
 
     def __init__(self, presynaptic_neurons, postsynaptic_neurons, connector,
                  synapse_type=None, source=None, receptor_type=None,
@@ -222,7 +229,8 @@ class Projection(object):
 
     # --- Methods for writing/reading information to/from file. ---------------
 
-    def get(self, attribute_names, format, gather=True, with_address=True):
+    def get(self, attribute_names, format, gather=True, with_address=True,
+            multiple_synapses='sum'):
         """
         Get the values of a given attribute (weight or delay) for all
         connections in this Projection.
@@ -232,28 +240,41 @@ class Projection(object):
             names.
         `format`:
             "list" or "array".
+        `gather`:
+            if True, get connection information from all MPI nodes, otherwise
+            only from connections that exist in this node.
 
-        With list format, returns a list of tuples. Each tuple contains the
-        indices of the pre- and post-synaptic cell followed by the attribute
-        values in the order given in `attribute_names`. Example::
+        With list format, returns a list of tuples. By default, each tuple
+        contains the indices of the pre- and post-synaptic cell followed by
+        the attribute values in the order given in `attribute_names`.
+        Example::
 
             >>> prj.get(["weight", "delay"], format="list")[:5]
-            [(TODO)]
+            [(0.0, 0.0, 0.3401892507507171, 0.1),
+             (0.0, 1.0, 0.7990713166233654, 0.30000000000000004),
+             (0.0, 2.0, 0.6180841812877726, 0.5),
+             (0.0, 3.0, 0.6758149775627305, 0.7000000000000001),
+             (0.0, 4.0, 0.7166906726862953, 0.9)]
+
+        If `with_address` is set to False, then the tuples will contain only the
+        attribute values, not the cell indices.
 
         With array format, returns a tuple of 2D NumPy arrays, one for each
         name in `attribute_names`. The array element X_ij contains the
         attribute value for the connection from the ith neuron in the pre-
         synaptic Population to the jth neuron in the post-synaptic Population,
         if a single such connection exists. If there are no such connections,
-        X_ij will be NaN. If there are multiple such connections, the summed
-        value will be given, which makes some sense for weights, but is
-        pretty meaningless for delays. Example::
+        X_ij will be NaN. Example::
 
             >>> weights, delays = prj.get(["weight", "delay"], format="array")
-            >>> weights.shape
-            TODO
+            >>> weights
+            array([[ 0.66210438,         nan,  0.10744555,  0.54557088],
+                   [ 0.3676134 ,         nan,  0.41463193,         nan],
+                   [ 0.57434871,  0.4329354 ,  0.58482943,  0.42863916]])
 
-        TODO: document "with_address"
+        If there are multiple such connections, the action to take is
+        controlled by the `multiple_synapses` argument, which must be one of
+        {'last', 'first', 'sum', 'min', 'max'}.
 
         Values will be expressed in the standard PyNN units (i.e. millivolts,
         nanoamps, milliseconds, microsiemens, nanofarads, event per second).
@@ -269,7 +290,7 @@ class Projection(object):
             names = list(attribute_names)
             if with_address:
                 names = ["presynaptic_index", "postsynaptic_index"] + names
-            values = self._get_attributes_as_list(*names)
+            values = self._get_attributes_as_list(names)
             if gather and self._simulator.state.num_processes > 1:
                 all_values = {self._simulator.state.mpi_rank: values}
                 all_values = recording.gather_dict(all_values, all=(gather == 'all'))
@@ -279,22 +300,26 @@ class Projection(object):
                 values = [val[0] for val in values]
             return values
         elif format == 'array':
+            if multiple_synapses not in Projection.MULTI_SYNAPSE_OPERATIONS:
+                raise ValueError("`multiple_synapses` argument must be one of {}".format(list(Projection.MULTI_SYNAPSE_OPERATIONS)))
             if gather and self._simulator.state.num_processes > 1:
                 # Node 0 is the only one creating a full connection matrix, and returning it (saving memory)
                 # Slaves nodes are returning list of connections, so this may be inconsistent...
                 names = list(attribute_names)
                 names = ["presynaptic_index", "postsynaptic_index"] + names
-                values = self._get_attributes_as_list(*names)
+                values = self._get_attributes_as_list(names)
                 all_values = {self._simulator.state.mpi_rank: values}
                 all_values = recording.gather_dict(all_values, all=(gather == 'all'))
                 if gather == 'all' or self._simulator.state.mpi_rank == 0:
                     tmp_values = reduce(operator.add, all_values.values())
-                    values = self._get_attributes_as_arrays(*attribute_names)
+                    values = self._get_attributes_as_arrays(attribute_names,
+                                                            multiple_synapses=multiple_synapses)
                     tmp_values = numpy.array(tmp_values)
                     for i in xrange(len(values)):
                         values[i][tmp_values[:, 0].astype(int), tmp_values[:, 1].astype(int)] = tmp_values[:, 2 + i]
             else:
-                values = self._get_attributes_as_arrays(*attribute_names)
+                values = self._get_attributes_as_arrays(attribute_names,
+                                                        multiple_synapses=multiple_synapses)
             if return_single:
                 if gather == 'all' or self._simulator.state.mpi_rank == 0:
                     assert len(values) == 1, values
@@ -304,10 +329,11 @@ class Projection(object):
         else:
             raise Exception("format must be 'list' or 'array'")
 
-    def _get_attributes_as_list(self, *names):
+    def _get_attributes_as_list(self, names):
         return [c.as_tuple(*names) for c in self.connections]
 
-    def _get_attributes_as_arrays(self, *names):
+    def _get_attributes_as_arrays(self, names, multiple_synapses='sum'):
+        multi_synapse_operation = Projection.MULTI_SYNAPSE_OPERATIONS[multiple_synapses]
         all_values = []
         for attribute_name in names:
             values = numpy.nan * numpy.ones((self.pre.size, self.post.size))
@@ -319,9 +345,7 @@ class Projection(object):
                 if numpy.isnan(values[addr]):
                     values[addr] = value
                 else:
-                    values[addr] += value   # addition is only appropriate for certain variables
-                                            # e.g. weight. Not appropriate for delays.
-                                            # What about synaptic parameters, e.g. wmax?
+                    values[addr] = multi_synapse_operation(values[addr], value)
             all_values.append(values)
         return all_values
 

--- a/pyNN/nest/projections.py
+++ b/pyNN/nest/projections.py
@@ -309,7 +309,7 @@ class Projection(common.Projection):
     #        file.write(lines, {'pre' : self.pre.label, 'post' : self.post.label})
     #        file.close()
 
-    def _get_attributes_as_list(self, *names):
+    def _get_attributes_as_list(self, names):
         nest_names = []
         for name in names:
             if name == 'presynaptic_index':
@@ -339,7 +339,8 @@ class Projection(common.Projection):
             values[i] = tuple(values[i])
         return values
 
-    def _get_attributes_as_arrays(self, *names):
+    def _get_attributes_as_arrays(self, names, multiple_synapses='sum'):
+        multi_synapse_operation = Projection.MULTI_SYNAPSE_OPERATIONS[multiple_synapses]
         all_values = []
         for attribute_name in names:
             if attribute_name[-1] == "s":  # weights --> weight, delays --> delay
@@ -354,7 +355,7 @@ class Projection(common.Projection):
                 if numpy.isnan(value_arr[addr]):
                     value_arr[addr] = value
                 else:
-                    value_arr[addr] += value
+                    value_arr[addr] = multi_synapse_operation(value_arr[addr], value)
             if attribute_name == 'weight':
                 value_arr *= 0.001
                 if self.receptor_type == 'inhibitory' and self.post.conductance_based:

--- a/pyNN/neuron/projections.py
+++ b/pyNN/neuron/projections.py
@@ -85,7 +85,7 @@ class Projection(common.Projection):
         """
         #logger.debug("Convergent connect. Weights=%s" % connection_parameters['weight'])
         postsynaptic_cell = self.post[postsynaptic_index]
-        if not isinstance(postsynaptic_cell, int) or postsynaptic_cell > simulator.state.gid_counter or postsynaptic_cell < 0:
+        if not isinstance(postsynaptic_cell, int) or not (0 <= postsynaptic_cell <= simulator.state.gid_counter):
             errmsg = "Invalid post-synaptic cell: %s (gid_counter=%d)" % (postsynaptic_cell, simulator.state.gid_counter)
             raise errors.ConnectionError(errmsg)
         for name, value in connection_parameters.items():

--- a/test/system/scenarios/test_connectors.py
+++ b/test/system/scenarios/test_connectors.py
@@ -158,6 +158,12 @@ def fixed_number_post_with_replacement(sim):
         row[numpy.isnan(row)] = 0
         assert_equal(row.sum(), 4.5)
 
+    weights2 = prj1.get('weight', format='array', gather=False, multiple_synapses='min')
+    for row in weights2:
+        n_nan = numpy.isnan(row).sum()
+        row[numpy.isnan(row)] = 0
+        assert_equal(row.sum(), (row.size - n_nan)*0.5)
+
 
 @register()
 def fixed_number_post_with_replacement_heterogeneous_parameters(sim):

--- a/test/unittests/test_projection.py
+++ b/test/unittests/test_projection.py
@@ -52,7 +52,7 @@ class ProjectionTest(unittest.TestCase):
         self.p3 = sim.Population(5, sim.IF_curr_alpha())
         self.syn1 = sim.StaticSynapse(weight=0.006, delay=0.5)
         self.random_connect = sim.FixedNumberPostConnector(n=2)
-        self.syn2 = sim.StaticSynapse(weight=0.012, delay=0.4)
+        self.syn2 = sim.StaticSynapse(weight=0.007, delay=0.4)
         self.all2all = sim.AllToAllConnector()
         self.syn3 = sim.TsodyksMarkramSynapse(weight=0.012, delay=0.6, U=0.2, tau_rec=50)
 
@@ -152,25 +152,25 @@ class ProjectionTest(unittest.TestCase):
         weights = prj.get("weight", format="list")
         weights = _sort_by_column(weights, 1)[:5]
         target = numpy.array(
-            [(0, 0, 0.012),
-             (1, 0, 0.012),
-             (2, 0, 0.012),
-             (3, 0, 0.012),
-             (4, 0, 0.012),])
+            [(0, 0, 0.007),
+             (1, 0, 0.007),
+             (2, 0, 0.007),
+             (3, 0, 0.007),
+             (4, 0, 0.007),])
         assert_array_equal(weights, target)
 
     @register()
     def test_get_weights_as_list_no_address(self, sim=sim):
         prj = sim.Projection(self.p1, self.p2, connector=self.all2all, synapse_type=self.syn2)
         weights = prj.get("weight", format="list", with_address=False)[:5]
-        target = 0.012 * numpy.ones((5,))
+        target = 0.007 * numpy.ones((5,))
         assert_array_equal(weights, target)
 
     @register()
     def test_get_weights_as_array(self, sim=sim):
         prj = sim.Projection(self.p1, self.p2, connector=self.all2all, synapse_type=self.syn2)
         weights = prj.get("weight", format="array", gather=False)  # use gather False because we are faking the MPI
-        target = 0.012 * numpy.ones((self.p1.size, self.p2.size))
+        target = 0.007 * numpy.ones((self.p1.size, self.p2.size))
         assert_array_equal(weights, target)
 
     @register()
@@ -185,6 +185,20 @@ class ProjectionTest(unittest.TestCase):
             [0.012, 0.012, 0.012, 0.012, 0.012],
             ])
         weights = prj.get("weight", format="array", gather=False)  # use gather False because we are faking the MPI
+        assert_array_equal(weights, target)
+
+    @register()
+    def test_get_weights_as_array_with_multapses_min(self, sim=sim):
+        C = sim.FixedNumberPreConnector(n=7, rng=MockRNG(delta=1))
+        prj = sim.Projection(self.p2, self.p3, C, synapse_type=self.syn1)
+        target = numpy.array([
+            [0.006, 0.006, 0.006, 0.006, 0.006],
+            [0.006, 0.006, 0.006, 0.006, 0.006],
+            [0.006, 0.006, 0.006, 0.006, 0.006],
+            [0.006, 0.006, 0.006, 0.006, 0.006],
+            ])
+        # use gather False because we are faking the MPI
+        weights = prj.get("weight", format="array", gather=False, multiple_synapses='min')
         assert_array_equal(weights, target)
 
     @register()
@@ -286,4 +300,4 @@ class ProjectionTest(unittest.TestCase):
                              synapse_type=self.syn2)
         n, bins = prj.weightHistogram(min=0.0, max=0.05)
         assert_array_equal(bins, numpy.linspace(0, 0.05, num=11))
-        assert_array_equal(n, numpy.array([0, 0, prj.size(), 0, 0, 0, 0, 0, 0, 0]))
+        assert_array_equal(n, numpy.array([0, prj.size(), 0, 0, 0, 0, 0, 0, 0, 0]))


### PR DESCRIPTION
 to control the combination of properties when there are multiple synapses connecting a pair of neurons (implements #362)