### PR TITLE
Changes to allow running nosetests for specific tests from system/scenarios

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -5,6 +5,7 @@ set -e  # stop execution in case of errors
 sudo apt-get install -qq python-numpy python3-numpy python-scipy python3-scipy libgsl0-dev  openmpi-bin libopenmpi-dev
 pip install -r requirements.txt
 pip install coverage coveralls
+pip install nose-testconfig
 source ci/install_brian.sh
 source ci/install_nest.sh
 source ci/install_neuron.sh

--- a/doc/developers/contributing.txt
+++ b/doc/developers/contributing.txt
@@ -114,6 +114,23 @@ The suggested way to do this is to write test functions, in a separate file,
 that take a simulator module as an argument, and then call these functions from
 ``test_neuron.py``, ``test_nest.py``, etc.
 
+System tests defined in the scenarios directory are treated as a single test 
+(test_scenarios()) while running nosetests. To run only the tests within a file
+named 'test_electrodes' located inside system/scenarios, use::
+
+    $ nosetests -s --tc=testFile:test_electrodes test_nest.py
+
+To run a single specific test named 'test_changing_electrode' located within 
+some file (and added to registry) inside system/scenarios, use::
+
+    $ nosetests -s --tc=testName:test_changing_electrode test_nest.py
+
+(note that this would also run the tests specified within the simulator specific
+files such as test_brian.py, test_nest.py and test_neuron.py will). To avoid 
+this, specify the test_scenarios function on the command line::
+
+    $ nosetests -s --tc=testName:test_changing_electrode test_nest.py:test_scenarios
+
 The ``test/unsorted`` directory contains a number of old tests that are either
 no longer useful or have not yet been adapted to the nose framework. These are
 not part of the test suite, but we are gradually adapting those tests that are

--- a/doc/developers/contributing.txt
+++ b/doc/developers/contributing.txt
@@ -125,9 +125,9 @@ some file (and added to registry) inside system/scenarios, use::
 
     $ nosetests -s --tc=testName:test_changing_electrode test_nest.py
 
-(note that this would also run the tests specified within the simulator specific
-files such as test_brian.py, test_nest.py and test_neuron.py will). To avoid 
-this, specify the test_scenarios function on the command line::
+Note that this would also run the tests specified within the simulator specific
+files such as test_brian.py, test_nest.py and test_neuron.py. To avoid 
+this, specify the 'test_scenarios function' on the command line::
 
     $ nosetests -s --tc=testName:test_changing_electrode test_nest.py:test_scenarios
 

--- a/test/system/scenarios/__init__.py
+++ b/test/system/scenarios/__init__.py
@@ -1,17 +1,25 @@
 # encoding: utf-8
+from testconfig import config
 
-from . import (scenario1,
-               scenario2,
-               scenario3,
-               ticket166,
-               test_simulation_control,
-               test_recording,
-               test_cell_types,
-               test_electrodes,
-               scenario4,
-               test_parameter_handling,
-               test_procedural_api,
-               issue274,
-               test_connectors,
-               issue231,
-               test_connection_handling)
+#import pdb
+#pdb.set_trace()
+
+if 'testFile' in config:
+    file_name = config['testFile']
+    exec("from . import ( %s )" % file_name)
+else:
+    from . import ( scenario1,
+                    scenario2,
+                    scenario3,
+                    ticket166,
+                    test_simulation_control,
+                    test_recording,
+                    test_cell_types,
+                    test_electrodes,
+                    scenario4,
+                    test_parameter_handling,
+                    test_procedural_api,
+                    issue274,
+                    test_connectors,
+                    issue231,
+                    test_connection_handling )

--- a/test/system/scenarios/registry.py
+++ b/test/system/scenarios/registry.py
@@ -1,10 +1,11 @@
+from testconfig import config
 
 registry = []
 
 
 def register(exclude=[]):
     def inner_register(scenario):
-        if scenario not in registry:
+        if scenario not in registry and not ('testName' in config and not scenario.__name__ == config['testName']):
             scenario.exclude = exclude
             registry.append(scenario)
         return scenario


### PR DESCRIPTION
**Background:** System tests defined in the `scenarios` directory are treated as a single test (`test_scenarios()`) while running nosetests.

The update proposed here attempts to allow the user to selectively run nosetests for the tests of interest in the `scenarios` directory. This makes use of the `nose-testconfig` plugin. Details here: https://pypi.python.org/pypi/nose-testconfig. It basically allows passing of test-specific (or test-run specific) configuration data to the tests being executed.

This can be installed with:
`pip install nose-testconfig`

We use this here to either specify the name of the testfile (containing the tests that we are interested in), or just the name of a specific test.

Examples:

**- To run all tests within a file named 'test_electrodes' located inside system/scenarios, we use:**
nosetests -s --tc=testFile:test_electrodes /home/shailesh/gits/PyNN/test/system/test_nest.py

**- To run a single specific test named 'test_changing_electrode' located within some file (and added to registry) inside system/scenarios, we use:**
nosetests -s --tc=testName:test_changing_electrode /home/shailesh/gits/PyNN/test/system/test_nest.py

NOTE: One limitation is that apart from the specified tests, the tests specified within the simulator specific files such as `test_brian.py`, `test_nest.py` and `test_neuron.py` will always be executed.

UPDATE: Travis fails currently because of the missing **_testconfig_** package