### PR TITLE
Fix for issue #483: evaluation of expected vector length rectified

### DIFF
--- a/pyNN/neuron/recording.py
+++ b/pyNN/neuron/recording.py
@@ -101,7 +101,7 @@ class Recorder(recording.Recorder):
         # assuming not using cvode, otherwise need to get times as well and use IrregularlySampledAnalogSignal
         if len(ids) > 0:
             signals = numpy.vstack((id._cell.traces[variable] for id in ids)).T
-            expected_length = int(simulator.state.tstop / self.sampling_interval) + 1
+            expected_length = numpy.rint(simulator.state.tstop / self.sampling_interval) + 1
             if signals.shape[0] != expected_length:  # generally due to floating point/rounding issues
                 signals = numpy.vstack((signals, signals[-1, :]))
         else:

--- a/pyNN/neuron/simulator.py
+++ b/pyNN/neuron/simulator.py
@@ -187,7 +187,9 @@ class _State(common.control.BaseState):
 
     def __get_min_delay(self):
         if h.min_delay < 0:
-            return 'auto'
+            local_minimum_delay = self.parallel_context.set_maxstep(self.default_maxstep)
+            self.min_delay = local_minimum_delay
+            return self.min_delay
         else:
             return h.min_delay
     min_delay = property(fset=__set_min_delay, fget=__get_min_delay)
@@ -240,12 +242,9 @@ class _State(common.control.BaseState):
             self.tstop = 0
             logger.debug("default_maxstep on host #%d = %g" % (self.mpi_rank, self.default_maxstep))
             logger.debug("local_minimum_delay on host #%d = %g" % (self.mpi_rank, local_minimum_delay))
-            if self.min_delay == 'auto':
-                self.min_delay = local_minimum_delay
-            else:
-                if self.num_processes > 1:
-                    assert local_minimum_delay >= self.min_delay, \
-                       "There are connections with delays (%g) shorter than the minimum delay (%g)" % (local_minimum_delay, self.min_delay)
+            if self.num_processes > 1:
+                assert local_minimum_delay >= self.min_delay, \
+                   "There are connections with delays (%g) shorter than the minimum delay (%g)" % (local_minimum_delay, self.min_delay)
 
     def _update_current_sources(self):
         for source in self.current_sources:

--- a/test/system/scenarios/test_electrodes.py
+++ b/test/system/scenarios/test_electrodes.py
@@ -116,7 +116,7 @@ def issue437(sim):
     If fails, run the test again to confirm. Passes 9/10 times on first attempt.
     """
     if not have_scipy:
-        raise SkipTest 
+        raise SkipTest
 
     v_rest = -60.0  # for this test keep v_rest < v_reset
     sim.setup(timestep=0.1, min_delay=0.1)
@@ -288,6 +288,29 @@ def issue451(sim):
     assert_true (all( (val.item()-v_rest)<1e-9 for val in v[:, 0]))
 
 
+@register()
+def issue483(sim):
+    """
+    Test to ensure that length of recorded voltage vector is as expected
+    (checks for the specific scenario that failed earlier)
+    """
+    dt = 0.1
+    sim.setup(timestep=dt, min_delay=dt)
+    p = sim.Population(1, sim.IF_curr_exp())
+    c = sim.DCSource(amplitude=0.5)
+    c.inject_into(p)
+    p.record('v')
+
+    simtime = 200.0
+    sim.run(100.0)
+    sim.run(100.0)
+
+    v = p.get_data().segments[0].filter(name="v")[0]
+
+    # check that the length of vm vector is as expected theoretically
+    assert (len(v) == (int(simtime/dt) + 1))
+
+
 if __name__ == '__main__':
     from pyNN.utility import get_simulator
     sim, args = get_simulator()
@@ -299,3 +322,4 @@ if __name__ == '__main__':
     issue442(sim)
     issue445(sim)
     issue451(sim)
+    issue483(sim)


### PR DESCRIPTION
Replaces `int()` with `numpy.rint()` to resolve #483
Test case created for future checks.