### PR TITLE
Fixes issue #487: Updates _update_iclamp() for NEURON

### DIFF
--- a/pyNN/neuron/simulator.py
+++ b/pyNN/neuron/simulator.py
@@ -247,17 +247,17 @@ class _State(common.control.BaseState):
                     assert local_minimum_delay >= self.min_delay, \
                        "There are connections with delays (%g) shorter than the minimum delay (%g)" % (local_minimum_delay, self.min_delay)
 
-    def _update_current_sources(self):
+    def _update_current_sources(self, tstop):
         for source in self.current_sources:
             for iclamp in source._devices:
-                source._update_iclamp(iclamp)
+                source._update_iclamp(iclamp, tstop)
 
     def run(self, simtime):
         """Advance the simulation for a certain time."""
         self.run_until(self.tstop + simtime)
 
     def run_until(self, tstop):
-        self._update_current_sources()
+        self._update_current_sources(tstop)
         self._pre_run()
         self.tstop = tstop
         #logger.info("Running the simulation until %g ms" % tstop)

--- a/pyNN/neuron/standardmodels/electrodes.py
+++ b/pyNN/neuron/standardmodels/electrodes.py
@@ -60,11 +60,11 @@ class NeuronCurrentSource(StandardCurrentSource):
             self._times = None
             self._generate()
         for iclamp in self._h_iclamps.values():
-            self._update_iclamp(iclamp)
+            self._update_iclamp(iclamp, 0.0)    # send tstop = 0.0 on _reset()
 
-    def _update_iclamp(self, iclamp):
+    def _update_iclamp(self, iclamp, tstop):
         if not self._is_playable:
-            iclamp.delay = max(0, self.start - simulator.state.t)
+            iclamp.delay = self.start
             iclamp.dur = self.stop - self.start
             iclamp.amp = self.amplitude
 
@@ -72,6 +72,16 @@ class NeuronCurrentSource(StandardCurrentSource):
             iclamp.delay = 0.0
             iclamp.dur = 1e12
             iclamp.amp = 0.0
+
+            # check exists only for StepCurrentSource (_is_playable = True, _is_computed = False)
+            # t_stop should be part of the time sequence to handle repeated runs
+            if not self._is_computed and tstop not in self._h_times.to_python():
+                ind = self._h_times.indwhere(">=", tstop)
+                if ind == -1:
+                    ind = self._h_times.size()
+                self._h_times.insrt(ind, tstop)
+                self._h_amplitudes.insrt(ind, self._h_amplitudes.x[int(ind)-1])
+                
             self._h_amplitudes.play(iclamp._ref_amp, self._h_times)
 
     def set_native_parameters(self, parameters):


### PR DESCRIPTION
This fix rectifies:
- DCSource 
- StepCurrentSource

under NEURON. It fixes the issue for simulations that are split into multiple runs.

Now output is equivalent when running:
```
run(200.0)
```
or
```
run(100.0)
run(100.0)
```