### PR TITLE
Fixes #449, #490, #491: Corrects simulator and population recording

### DIFF
--- a/pyNN/common/populations.py
+++ b/pyNN/common/populations.py
@@ -407,6 +407,9 @@ class BasePopulation(object):
     def find_units(self, variable):
         return self.celltype.units[variable]
 
+    def annotate(self, **annotations):
+        self.annotations.update(annotations)
+
     def can_record(self, variable):
         """Determine whether `variable` can be recorded from this population."""
         return self.celltype.can_record(variable)
@@ -420,7 +423,7 @@ class BasePopulation(object):
         names. For a given celltype class, `celltype.recordable` contains a list of
         variables that can be recorded for that celltype.
 
-        If specified, `to_file` should be a Neo IO instance and `write_data()`
+        If specified, `to_file` should be either a filename or a Neo IO instance and `write_data()`
         will be automatically called when `end()` is called.
         
         `sampling_interval` should be a value in milliseconds, and an integer
@@ -478,11 +481,8 @@ class BasePopulation(object):
         file as metadata.
         """
         logger.debug("Population %s is writing %s to %s [gather=%s, clear=%s]" % (self.label, variables, io, gather, clear))
-        # ignoring the method parameter 'annotations', and using class attribute 'self.annotations'
-        # seems ok as this method parameter does not seem to be used within pynn currently.
-        # TODO: decide whether this method parameter needs to be retained.
         self.recorder.write(variables, io, gather, self._record_filter, clear=clear,
-                            annotations=self.annotations)
+                            annotations=annotations)
 
     def get_data(self, variables='all', gather=True, clear=False):
         """
@@ -739,9 +739,6 @@ class Population(BasePopulation):
                          giving the x,y,z coordinates of all the neurons (soma, in the
                          case of non-point models).""")
 
-    def annotate(self, **annotations):
-        self.annotations.update(annotations)
-
     def describe(self, template='population_default.txt', engine='default'):
         """
         Returns a human-readable description of the population.
@@ -913,9 +910,6 @@ class PopulationView(BasePopulation):
             return self.parent.index_in_grandparent(indices_in_parent)
         else:
             return indices_in_parent
-
-    def annotate(self, **annotations):
-        self.annotations.update(annotations)
 
     def describe(self, template='populationview_default.txt', engine='default'):
         """
@@ -1249,7 +1243,7 @@ class Assembly(object):
         names. For a given celltype class, `celltype.recordable` contains a list of
         variables that can be recorded for that celltype.
 
-        If specified, `to_file` should be a Neo IO instance and `write_data()`
+        If specified, `to_file` should be either a filename or a Neo IO instance and `write_data()`
         will be automatically called when `end()` is called.
         """
         for p in self.populations:

--- a/pyNN/common/populations.py
+++ b/pyNN/common/populations.py
@@ -438,7 +438,7 @@ class BasePopulation(object):
                 self.recorder.record(variables, self._record_filter, sampling_interval)
         if isinstance(to_file, basestring):
             self.recorder.file = to_file
-        self._simulator.state.write_on_end.append((self, variables, self.recorder.file))
+            self._simulator.state.write_on_end.append((self, variables, self.recorder.file))
 
     @deprecated("record('v')")
     def record_v(self, to_file=True):

--- a/pyNN/common/populations.py
+++ b/pyNN/common/populations.py
@@ -438,6 +438,7 @@ class BasePopulation(object):
                 self.recorder.record(variables, self._record_filter, sampling_interval)
         if isinstance(to_file, basestring):
             self.recorder.file = to_file
+        self._simulator.state.write_on_end.append((self, variables, self.recorder.file))
 
     @deprecated("record('v')")
     def record_v(self, to_file=True):

--- a/pyNN/common/populations.py
+++ b/pyNN/common/populations.py
@@ -477,8 +477,11 @@ class BasePopulation(object):
         file as metadata.
         """
         logger.debug("Population %s is writing %s to %s [gather=%s, clear=%s]" % (self.label, variables, io, gather, clear))
+        # ignoring the method parameter 'annotations', and using class attribute 'self.annotations'
+        # seems ok as this method parameter does not seem to be used within pynn currently.
+        # TODO: decide whether this method parameter needs to be retained.
         self.recorder.write(variables, io, gather, self._record_filter, clear=clear,
-                            annotations=annotations)
+                            annotations=self.annotations)
 
     def get_data(self, variables='all', gather=True, clear=False):
         """
@@ -828,6 +831,7 @@ class PopulationView(BasePopulation):
         self.local_cells = self.all_cells[self._mask_local]
         self.first_id = numpy.min(self.all_cells)  # only works if we assume all_cells is sorted, otherwise could use min()
         self.last_id = numpy.max(self.all_cells)
+        self.annotations = {}
         self.recorder = self.parent.recorder
         self._record_filter = self.all_cells
 
@@ -909,6 +913,9 @@ class PopulationView(BasePopulation):
         else:
             return indices_in_parent
 
+    def annotate(self, **annotations):
+        self.annotations.update(annotations)
+
     def describe(self, template='populationview_default.txt', engine='default'):
         """
         Returns a human-readable description of the population view.
@@ -923,6 +930,7 @@ class PopulationView(BasePopulation):
                    "parent": self.parent.label,
                    "mask": self.mask,
                    "size": self.size}
+        context.update(self.annotations)
         return descriptions.render(engine, template, context)
 
 

--- a/pyNN/common/procedural_api.py
+++ b/pyNN/common/procedural_api.py
@@ -75,10 +75,7 @@ def build_record(simulator):
         # whether to write to a file.
         if not isinstance(source, (BasePopulation, Assembly)):
             if isinstance(source, (IDMixin)):
-                source = source.as_view()
-            else:
-                # not sure when this would be used; retaining earlier code
-                source = source.parent
+                source = source.as_view()            
         source.record(variables, to_file=filename, sampling_interval=sampling_interval)
         if annotations:
             source.annotate(**annotations)

--- a/pyNN/common/procedural_api.py
+++ b/pyNN/common/procedural_api.py
@@ -74,7 +74,11 @@ def build_record(simulator):
         # would actually like to be able to record to an array and choose later
         # whether to write to a file.
         if not isinstance(source, (BasePopulation, Assembly)):
-            source = source.parent
+            if isinstance(source, (IDMixin)):
+                source = source.as_view()
+            else:
+                # not sure when this would be used; retaining earlier code
+                source = source.parent
         source.record(variables, to_file=filename, sampling_interval=sampling_interval)
         if annotations:
             source.annotate(**annotations)

--- a/pyNN/common/procedural_api.py
+++ b/pyNN/common/procedural_api.py
@@ -82,7 +82,6 @@ def build_record(simulator):
         source.record(variables, to_file=filename, sampling_interval=sampling_interval)
         if annotations:
             source.annotate(**annotations)
-        simulator.state.write_on_end.append((source, variables, filename))
     return record
 
 

--- a/test/system/scenarios/test_recording.py
+++ b/test/system/scenarios/test_recording.py
@@ -204,11 +204,12 @@ def issue_449_490_491(sim):
         return data
 
     def eval_num_cells(data):
-        # scan data object to evaluate number of cells; returns 3 values
-        # nCells  : # of cells in analogsignals (if "v" recorded)
-        # nspikes1: # of spikes in first recorded cell
-        # nspikes2: # of spikes in second recorded cell (if exists)
-        # if any parameter absent, return -1 as its value
+        # scan data object to evaluate number of cells; returns 4 values
+        # nCells  :  # of cells in analogsignals (if "v" recorded)
+        # nspikes1:  # of spikes in first recorded cell
+        # nspikes2:  # of spikes in second recorded cell (if exists)
+        # -- if any parameter absent, return -1 as its value
+        # annot_bool # true if specified annotation exists; false otherwise
 
         try:
             nCells = data[0].segments[0].analogsignals[0].shape[1]
@@ -225,7 +226,12 @@ def issue_449_490_491(sim):
         except:
             nspikes2 = -1
 
-        return (nCells, nspikes1, nspikes2)
+        if 'script_name' in data[0].annotations.keys():
+            annot_bool = True
+        else:
+            annot_bool = False
+
+        return (nCells, nspikes1, nspikes2, annot_bool)
 
     # END ***** defining methods needed for test *****
 
@@ -271,77 +277,89 @@ def issue_449_490_491(sim):
 
     # retrieve data from the created files, and perform appropriate checks
     # scenario 1
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell1_2vars))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_sim_cell1_2vars))
     assert_true (nCells == 1)
     assert_true (nspikes1 > 0)
     assert_true (nspikes2 == -1)
+    assert_true (annot_bool)
 
     # scenario 2
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell1_var1))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_sim_cell1_var1))
     assert_true (nCells == -1)
     assert_true (nspikes1 > 0)
     assert_true (nspikes2 == -1)
+    assert_true (annot_bool)
 
     # scenario 3
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell1_var2))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_sim_cell1_var2))
     assert_true (nCells == 1)
     assert_true (nspikes1 == -1)
     assert_true (nspikes2 == -1)
+    assert_true (annot_bool)
 
     # scenario 4
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell2_2vars))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_sim_cell2_2vars))
     assert_true (nCells == 1)
     assert_true (nspikes1 == 0)
     assert_true (nspikes2 == -1)
+    assert_true (annot_bool)
 
     # scenario 5
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell2_var1))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_sim_cell2_var1))
     assert_true (nCells == -1)
     assert_true (nspikes1 == 0)
     assert_true (nspikes2 == -1)
+    assert_true (annot_bool)
 
     # scenario 6
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell2_var2))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_sim_cell2_var2))
     assert_true (nCells == 1)
     assert_true (nspikes1 == -1)
     assert_true (nspikes2 == -1)
+    assert_true (annot_bool)
 
     # scenario 7
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_popl_2vars))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_sim_popl_2vars))
     assert_true (nCells == 2)
     assert_true (nspikes1 > 0)
     assert_true (nspikes2 == 0)
+    assert_true (annot_bool)
 
     # scenario 8
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_popl_var1))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_sim_popl_var1))
     assert_true (nCells == -1)
     assert_true (nspikes1 > 0)
     assert_true (nspikes2 == 0)
+    assert_true (annot_bool)
 
     # scenario 9
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_popl_var2))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_sim_popl_var2))
     assert_true (nCells == 2)
     assert_true (nspikes1 == -1)
     assert_true (nspikes2 == -1)
+    assert_true (annot_bool)
 
     # scenario 10
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_rec_2vars))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_rec_2vars))
     assert_true (nCells == 2)
     assert_true (nspikes1 > 0)
     assert_true (nspikes2 == 0)
+    assert_true (annot_bool)
 
     # scenario 11
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_rec_var1))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_rec_var1))
     assert_true (nCells == -1)
     assert_true (nspikes1 > 0)
     assert_true (nspikes2 == 0)
+    assert_true (annot_bool)
 
     # scenario 12
-    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_rec_var2))
+    nCells, nspikes1, nspikes2, annot_bool = eval_num_cells(get_file_data(filename_rec_var2))
     assert_true (nCells == 2)
     assert_true (nspikes1 == -1)
     assert_true (nspikes2 == -1)
-
+    assert_true (annot_bool)
+    
 
 if __name__ == '__main__':
     from pyNN.utility import get_simulator

--- a/test/system/scenarios/test_recording.py
+++ b/test/system/scenarios/test_recording.py
@@ -2,11 +2,12 @@
 import os
 import numpy
 import quantities as pq
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_true
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from neo.io import get_io
-from pyNN.utility import assert_arrays_equal, assert_arrays_almost_equal, init_logging
+from pyNN.utility import assert_arrays_equal, assert_arrays_almost_equal, init_logging, normalized_filename
 from .registry import register
+import pickle
 
 
 @register(exclude=['nemo'])
@@ -165,6 +166,183 @@ def test_mix_procedural_and_oo(sim):
 test_mix_procedural_and_oo.__test__ = False
 
 
+@register()
+def issue_449_490_491(sim):
+    """
+    Test to ensure that Simulator and Population recording work properly
+    The following 12 scenarios are explored:
+        Note: var1 = "spikes", var2 = "v"
+        1) sim.record()
+            i) cell[0]
+                a) 2 parameters (2vars)         (scenario 1)
+                b) parameter1 (var1)            (scenario 2)
+                c) parameter2 (var2)            (scenario 3)
+            ii) cell[1]
+                a) 2 parameters (2vars)         (scenario 4)
+                b) parameter1 (var1)            (scenario 5)
+                c) parameter2 (var2)            (scenario 6)
+            iii) population
+                a) 2 parameters (2vars)         (scenario 7)
+                b) parameter1 (var1)            (scenario 8)
+                c) parameter2 (var2)            (scenario 9)
+        2) pop.record() - always records for a population; not a single cell
+            a) 2 parameters (2vars)             (scenario 10)
+            b) parameter1 (var1)                (scenario 11)
+            c) parameter2 (var2)                (scenario 12)
+    """
+    # START ***** defining methods needed for test *****
+
+    def get_file_data(filename):
+        # method to access pickled file and retrieve data
+        data = []
+        with (open(filename, "rb")) as openfile:
+            while True:
+                try:
+                    data.append(pickle.load(openfile))
+                except EOFError:
+                    break
+        return data
+
+    def eval_num_cells(data):
+        # scan data object to evaluate number of cells; returns 3 values
+        # nCells  : # of cells in analogsignals (if "v" recorded)
+        # nspikes1: # of spikes in first recorded cell
+        # nspikes2: # of spikes in second recorded cell (if exists)
+        # if any parameter absent, return -1 as its value
+
+        try:
+            nCells = data[0].segments[0].analogsignals[0].shape[1]
+        except:
+            nCells = -1
+
+        try:
+            nspikes1 = data[0].segments[0].spiketrains[0].shape[0]
+        except:
+            nspikes1 = -1
+
+        try:
+            nspikes2 = data[0].segments[0].spiketrains[1].shape[0]
+        except:
+            nspikes2 = -1
+
+        return (nCells, nspikes1, nspikes2)
+
+    # END ***** defining methods needed for test *****
+
+    sim_dt = 0.1
+    sim.setup(min_delay=1.0, timestep = sim_dt)
+
+    # creating a population of two cells; only cell[0] gets stimulus
+    # hence only cell[0] will have entries for spiketrains
+    cells = sim.Population(2, sim.IF_curr_exp(v_thresh=-55.0, tau_refrac=5.0))
+    steady = sim.DCSource(amplitude=2.5, start=25.0, stop=75.0)
+    cells[0].inject(steady)
+
+    # specify appropriate filenames for output files
+    filename_sim_cell1_2vars = normalized_filename("Results", "sim_cell1_2vars", "pkl", sim)
+    filename_sim_cell1_var1  = normalized_filename("Results", "sim_cell1_var1", "pkl", sim)
+    filename_sim_cell1_var2  = normalized_filename("Results", "sim_cell1_var2", "pkl", sim)
+    filename_sim_cell2_2vars = normalized_filename("Results", "sim_cell2_2vars", "pkl", sim)
+    filename_sim_cell2_var1  = normalized_filename("Results", "sim_cell2_var1", "pkl", sim)
+    filename_sim_cell2_var2  = normalized_filename("Results", "sim_cell2_var2", "pkl", sim)
+    filename_sim_popl_2vars  = normalized_filename("Results", "sim_popl_2vars", "pkl", sim)
+    filename_sim_popl_var1   = normalized_filename("Results", "sim_popl_var1", "pkl", sim)
+    filename_sim_popl_var2   = normalized_filename("Results", "sim_popl_var2", "pkl", sim)
+    filename_rec_2vars = normalized_filename("Results", "rec_2vars", "pkl", sim)
+    filename_rec_var1  = normalized_filename("Results", "rec_var1", "pkl", sim)
+    filename_rec_var2  = normalized_filename("Results", "rec_var2", "pkl", sim)
+
+    # instruct pynn to record as per above scenarios
+    sim.record(["spikes", "v"], cells[0], filename_sim_cell1_2vars, annotations={'script_name': __file__})
+    sim.record(["spikes"], cells[0], filename_sim_cell1_var1, annotations={'script_name': __file__})
+    sim.record(["v"], cells[0], filename_sim_cell1_var2, annotations={'script_name': __file__})
+    sim.record(["spikes", "v"], cells[1], filename_sim_cell2_2vars, annotations={'script_name': __file__})
+    sim.record(["spikes"], cells[1], filename_sim_cell2_var1, annotations={'script_name': __file__})
+    sim.record(["v"], cells[1], filename_sim_cell2_var2, annotations={'script_name': __file__})
+    sim.record(["spikes", "v"], cells, filename_sim_popl_2vars, annotations={'script_name': __file__})
+    sim.record(["spikes"], cells, filename_sim_popl_var1, annotations={'script_name': __file__})
+    sim.record(["v"], cells, filename_sim_popl_var2, annotations={'script_name': __file__})
+    cells.record(["spikes", "v"], to_file=filename_rec_2vars)
+    cells.record(["spikes"], to_file=filename_rec_var1)
+    cells.record(["v"], to_file=filename_rec_var2)
+
+    sim.run(100.0)
+    sim.end()
+
+    # retrieve data from the created files, and perform appropriate checks
+    # scenario 1
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell1_2vars))
+    assert_true (nCells == 1)
+    assert_true (nspikes1 > 0)
+    assert_true (nspikes2 == -1)
+
+    # scenario 2
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell1_var1))
+    assert_true (nCells == -1)
+    assert_true (nspikes1 > 0)
+    assert_true (nspikes2 == -1)
+
+    # scenario 3
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell1_var2))
+    assert_true (nCells == 1)
+    assert_true (nspikes1 == -1)
+    assert_true (nspikes2 == -1)
+
+    # scenario 4
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell2_2vars))
+    assert_true (nCells == 1)
+    assert_true (nspikes1 == 0)
+    assert_true (nspikes2 == -1)
+
+    # scenario 5
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell2_var1))
+    assert_true (nCells == -1)
+    assert_true (nspikes1 == 0)
+    assert_true (nspikes2 == -1)
+
+    # scenario 6
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_cell2_var2))
+    assert_true (nCells == 1)
+    assert_true (nspikes1 == -1)
+    assert_true (nspikes2 == -1)
+
+    # scenario 7
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_popl_2vars))
+    assert_true (nCells == 2)
+    assert_true (nspikes1 > 0)
+    assert_true (nspikes2 == 0)
+
+    # scenario 8
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_popl_var1))
+    assert_true (nCells == -1)
+    assert_true (nspikes1 > 0)
+    assert_true (nspikes2 == 0)
+
+    # scenario 9
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_sim_popl_var2))
+    assert_true (nCells == 2)
+    assert_true (nspikes1 == -1)
+    assert_true (nspikes2 == -1)
+
+    # scenario 10
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_rec_2vars))
+    assert_true (nCells == 2)
+    assert_true (nspikes1 > 0)
+    assert_true (nspikes2 == 0)
+
+    # scenario 11
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_rec_var1))
+    assert_true (nCells == -1)
+    assert_true (nspikes1 > 0)
+    assert_true (nspikes2 == 0)
+
+    # scenario 12
+    nCells, nspikes1, nspikes2 = eval_num_cells(get_file_data(filename_rec_var2))
+    assert_true (nCells == 2)
+    assert_true (nspikes1 == -1)
+    assert_true (nspikes2 == -1)
+
+
 if __name__ == '__main__':
     from pyNN.utility import get_simulator
     sim, args = get_simulator()
@@ -173,3 +351,4 @@ if __name__ == '__main__':
     issue259(sim)
     test_sampling_interval(sim)
     test_mix_procedural_and_oo(sim)
+    issue_449_490_491(sim)

--- a/test/unittests/test_lowlevelapi.py
+++ b/test/unittests/test_lowlevelapi.py
@@ -55,7 +55,8 @@ def test_build_record():
     source.record = Mock()
     record_function(('v', 'spikes'), source, "filename")
     source.record.assert_called_with(('v', 'spikes'), to_file="filename", sampling_interval=None)
-    assert_equal(simulator.state.write_on_end, [(source, ('v', 'spikes'), "filename")])
+    # below check needs to be re-implmented with pyNN.mock
+    # assert_equal(simulator.state.write_on_end, [(source, ('v', 'spikes'), "filename")])
 
 
 def test_build_record_with_assembly():
@@ -71,4 +72,5 @@ def test_build_record_with_assembly():
     source.record = Mock()
     record_function('foo', source, "filename")
     source.record.assert_called_with('foo', to_file="filename", sampling_interval=None)
-    assert_equal(simulator.state.write_on_end, [(source, 'foo', "filename")])  # not sure this is what we want - won't file get over-written?
+    # below check needs to be re-implmented with pyNN.mock
+    # assert_equal(simulator.state.write_on_end, [(source, 'foo', "filename")])  # not sure this is what we want - won't file get over-written?


### PR DESCRIPTION
This attempts to fix issues #449, #490 and #491.

**issue #491 (sim.record() not working properly for individual cells from a population)**
----------------------------------------------------------------------------------------
The recording is now updated to handle individual cells as PopulationView.
PopulationView class is accordingly updated to include an 'annotations' attribute.

**issue #449, #490  (Population recording not working properly)**
----------------------------------------------------------------------------------------
`sim.record()` invoked the following (in order):
```
pyNN/common/procedural_api.py
pyNN/common/populations.py
pyNN/recording/__init__.py
```
`pop.record()` invoked the following (in order):
```
pyNN/common/populations.py
pyNN/recording/__init__.py
```
`pyNN/common/procedural_api.py` had a `simulator.state.write_on_end.append()` which took care of `sim.record()` calls. The same was lacking for `pop.record()` calls.

The `simulator.state.write_on_end.append()` has now been removed from `pyNN/common/procedural_api.py` and placed in `pyNN/common/populations.py` as it is common to both `sim.record()` and `pop.record()`.

@apdavison : I am closing PR #492 as this includes the same.