### PR TITLE
Fixes 459: Extends find_units() for neuron parameters

### DIFF
--- a/pyNN/common/populations.py
+++ b/pyNN/common/populations.py
@@ -406,8 +406,8 @@ class BasePopulation(object):
 
     def find_units(self, variable):
         """
-        Returns units of the specified variable. Works for all the recordable
-        variables and neuron parameters of all standard models.
+        Returns units of the specified variable or parameter, as a string.
+        Works for all the recordable variables and neuron parameters of all standard models.
         """
         return self.celltype.units[variable]
 
@@ -1036,8 +1036,8 @@ class Assembly(object):
 
     def find_units(self, variable):
         """
-        Returns units of the specified variable. Works for all the recordable
-        variables and neuron parameters of all standard models.
+        Returns units of the specified variable or parameter, as a string.
+        Works for all the recordable variables and neuron parameters of all standard models.
         """
         units = set(p.find_units(variable) for p in self.populations)
         if len(units) > 1:

--- a/pyNN/common/populations.py
+++ b/pyNN/common/populations.py
@@ -405,6 +405,10 @@ class BasePopulation(object):
             self.initial_values[variable] = initial_value
 
     def find_units(self, variable):
+        """
+        Returns units of the specified variable. Works for all the recordable
+        variables and neuron parameters of all standard models.
+        """
         return self.celltype.units[variable]
 
     def can_record(self, variable):
@@ -1031,6 +1035,10 @@ class Assembly(object):
         return rts
 
     def find_units(self, variable):
+        """
+        Returns units of the specified variable. Works for all the recordable
+        variables and neuron parameters of all standard models.
+        """
         units = set(p.find_units(variable) for p in self.populations)
         if len(units) > 1:
             raise ValueError("Inconsistent units")

--- a/pyNN/standardmodels/cells.py
+++ b/pyNN/standardmodels/cells.py
@@ -60,6 +60,15 @@ class IF_curr_alpha(StandardCellType):
         'v': 'mV',
         'isyn_exc': 'nA',
         'isyn_inh': 'nA',
+        'v_rest': 'mV',
+        'cm': 'nF',
+        'tau_m': 'ms',
+        'tau_refrac': 'ms',
+        'tau_syn_E': 'ms',
+        'tau_syn_I': 'ms',
+        'i_offset': 'nA',
+        'v_reset': 'mV',
+        'v_thresh': 'mV',
     }
 
 
@@ -92,6 +101,15 @@ class IF_curr_exp(StandardCellType):
         'v': 'mV',
         'isyn_exc': 'nA',
         'isyn_inh': 'nA',
+        'v_rest': 'mV',
+        'cm': 'nF',
+        'tau_m': 'ms',
+        'tau_refrac': 'ms',
+        'tau_syn_E': 'ms',
+        'tau_syn_I': 'ms',
+        'i_offset': 'nA',
+        'v_reset': 'mV',
+        'v_thresh': 'mV',
     }
 
 
@@ -124,6 +142,17 @@ class IF_cond_alpha(StandardCellType):
         'v': 'mV',
         'gsyn_exc': 'uS',
         'gsyn_inh': 'uS',
+        'v_rest': 'mV',
+        'cm': 'nF',
+        'tau_m': 'ms',
+        'tau_refrac': 'ms',
+        'tau_syn_E': 'ms',
+        'tau_syn_I': 'ms',
+        'e_rev_E': 'mV',
+        'e_rev_I': 'mV',
+        'v_thresh': 'mV',
+        'v_reset': 'mV',
+        'i_offset': 'nA',
     }
 
 
@@ -156,6 +185,17 @@ class IF_cond_exp(StandardCellType):
         'v': 'mV',
         'gsyn_exc': 'uS',
         'gsyn_inh': 'uS',
+        'v_rest': 'mV',
+        'cm': 'nF',
+        'tau_m': 'ms',
+        'tau_refrac': 'ms',
+        'tau_syn_E': 'ms',
+        'tau_syn_I': 'ms',
+        'e_rev_E': 'mV',
+        'e_rev_I': 'mV',
+        'v_thresh': 'mV',
+        'v_reset': 'mV',
+        'i_offset': 'nA',
     }
 
 
@@ -205,6 +245,23 @@ class IF_cond_exp_gsfa_grr(StandardCellType):
         'g_s': 'nS',
         'gsyn_exc': 'uS',
         'gsyn_inh': 'uS',
+        'v_rest': 'mV',
+        'cm': 'nF',
+        'tau_m': 'ms',
+        'tau_refrac': 'ms',
+        'tau_syn_E': 'ms',
+        'tau_syn_I': 'ms',
+        'e_rev_E': 'mV',
+        'e_rev_I': 'mV',
+        'v_thresh': 'mV',
+        'v_reset': 'mV',
+        'i_offset': 'nA',
+        'tau_sfa': 'ms',
+        'e_rev_sfa': 'mV',
+        'q_sfa': 'nS',
+        'tau_rr': 'ms',
+        'e_rev_rr': 'mV',
+        'q_rr': 'nS',
     }
 
 
@@ -238,6 +295,13 @@ class IF_facets_hardware1(StandardCellType):
         'v': 'mV',
         'gsyn_exc': 'uS',
         'gsyn_inh': 'uS',
+        'g_leak': 'nS',
+        'tau_syn_E': 'ms',
+        'tau_syn_I': 'ms',
+        'v_reset': 'mV',
+        'e_rev_I': 'mV',
+        'v_rest': 'mV',
+        'v_thresh': 'mV',
     }
 
 
@@ -273,6 +337,19 @@ class HH_cond_exp(StandardCellType):
         'v': 'mV',
         'gsyn_exc': 'uS',
         'gsyn_inh': 'uS',
+        'gbar_Na': 'uS',
+        'gbar_K': 'uS',
+        'g_leak': 'uS',
+        'cm': 'nF',
+        'v_offset': 'mV',
+        'e_rev_Na': 'mV',
+        'e_rev_K': 'mV',
+        'e_rev_leak': 'mV',
+        'e_rev_E': 'mV',
+        'e_rev_I': 'mV',
+        'tau_syn_E': 'ms',
+        'tau_syn_I': 'ms',
+        'i_offset': 'nA',
     }
 
 
@@ -317,6 +394,22 @@ class EIF_cond_alpha_isfa_ista(StandardCellType):
         'w': 'nA',
         'gsyn_exc': 'uS',
         'gsyn_inh': 'uS',
+        'cm': 'nF',
+        'tau_refrac': 'ms',
+        'v_spike': 'mV',
+        'v_reset': 'mV',
+        'v_rest': 'mV',
+        'tau_m': 'ms',
+        'i_offset': 'nA',
+        'a': 'nS',
+        'b': 'nA',
+        'delta_T': 'mV',
+        'tau_w': 'ms',
+        'v_thresh': 'mV',
+        'e_rev_E': 'mV',
+        'tau_syn_E': 'ms',
+        'e_rev_I': 'mV',
+        'tau_syn_I': 'ms',
     }
 
 
@@ -361,6 +454,22 @@ class EIF_cond_exp_isfa_ista(StandardCellType):
         'w': 'nA',
         'gsyn_exc': 'uS',
         'gsyn_inh': 'uS',
+        'cm': 'nF',
+        'tau_refrac': 'ms',
+        'v_spike': 'mV',
+        'v_reset': 'mV',
+        'v_rest': 'mV',
+        'tau_m': 'ms',
+        'i_offset': 'nA',
+        'a': 'nS',
+        'b': 'nA',
+        'delta_T': 'mV',
+        'tau_w': 'ms',
+        'v_thresh': 'mV',
+        'e_rev_E': 'mV',
+        'tau_syn_E': 'ms',
+        'e_rev_I': 'mV',
+        'tau_syn_I': 'ms',
     }
 
 
@@ -374,7 +483,7 @@ class Izhikevich(StandardCellType):
         du/dt = a*(b*v - u)
 
     Synapses are modeled as Dirac delta currents (voltage step), as in the original model
-    
+
     NOTE: name should probably be changed to match standard nomenclature,
     e.g. QIF_cond_delta_etc_etc, although keeping "Izhikevich" as an alias would be good
 
@@ -397,6 +506,11 @@ class Izhikevich(StandardCellType):
     units = {
         'v': 'mV',
         'u': 'mV/ms',
+        'a': '/ms',
+        'b': '/ms',
+        'c': 'mV',
+        'd': 'mV/ms',
+        'i_offset': 'nA',
     }
 
 
@@ -457,6 +571,31 @@ class GIF_cond_exp(StandardCellType):
         'gsyn_inh': 'uS',
         'i_eta': 'nA',
         'v_t': 'mV',
+        'v_rest': 'mV',
+        'cm': 'nF',
+        'tau_m': 'ms',
+        'tau_refrac': 'ms',
+        'tau_syn_E': 'ms',
+        'tau_syn_I': 'ms',
+        'e_rev_E': 'mV',
+        'e_rev_I': 'mV',
+        'v_reset': 'mV',
+        'i_offset': 'nA',
+        'delta_v': 'mV',
+        'v_t_star': 'mV',
+        'lambda0': 'Hz',
+        'tau_eta1': 'ms',
+        'tau_eta2': 'ms',
+        'tau_eta3': 'ms',
+        'tau_gamma1': 'ms',
+        'tau_gamma2': 'ms',
+        'tau_gamma3': 'ms',
+        'a_eta1': 'nA',
+        'a_eta2': 'nA',
+        'a_eta3': 'nA',
+        'a_gamma1': 'mV',
+        'a_gamma2': 'mV',
+        'a_gamma3': 'mV',
     }
 
 
@@ -471,6 +610,11 @@ class SpikeSourcePoisson(StandardCellType):
     recordable = ['spikes']
     injectable = False
     receptor_types = ()
+    units = {
+        'rate': 'Hz',
+        'start': 'ms',
+        'duration': 'ms',
+    }
 
 
 class SpikeSourcePoissonRefractory(StandardCellType):
@@ -485,6 +629,12 @@ class SpikeSourcePoissonRefractory(StandardCellType):
     recordable = ['spikes']
     injectable = False
     receptor_types = ()
+    units = {
+        'rate': 'Hz',
+        'tau_refrac': 'ms',
+        'start': 'ms',
+        'duration': 'ms',
+    }
 
 
 class SpikeSourceGamma(StandardCellType):
@@ -502,6 +652,12 @@ class SpikeSourceGamma(StandardCellType):
     recordable = ['spikes']
     injectable = False
     receptor_types = ()
+    units = {
+        'alpha': 'dimensionless',
+        'beta': 'Hz',
+        'start': 'ms',
+        'duration': 'ms',
+    }
 
 
 class SpikeSourceInhGamma(StandardCellType):
@@ -523,6 +679,13 @@ class SpikeSourceInhGamma(StandardCellType):
     recordable = ['spikes']
     injectable = False
     receptor_types = ()
+    units = {
+        'a': 'dimensionless',
+        'b': 's',
+        'tbins': 'ms',
+        'start': 'ms',
+        'duration': 'ms',
+    }
 
 
 class SpikeSourceArray(StandardCellType):
@@ -532,3 +695,6 @@ class SpikeSourceArray(StandardCellType):
     recordable = ['spikes']
     injectable = False
     receptor_types = ()
+    units = {
+        'spike_times': 'ms',
+    }


### PR DESCRIPTION
**Addresses issue #459** 
find_units() should now return units for both:
- recordable variables, and
- neuron parameters

for all standard models