### PR TITLE
Fixes issue #499: updates sim.end() for Brian

### DIFF
--- a/pyNN/brian/__init__.py
+++ b/pyNN/brian/__init__.py
@@ -54,7 +54,6 @@ def end(compatible_output=True):
     for (population, variables, filename) in simulator.state.write_on_end:
         io = get_io(filename)
         population.write_data(io, variables)
-    simulator.state.clear()
     simulator.state.write_on_end = []
     # should have common implementation of end()
 

--- a/test/system/scenarios/test_recording.py
+++ b/test/system/scenarios/test_recording.py
@@ -359,7 +359,25 @@ def issue_449_490_491(sim):
     assert_true (nspikes1 == -1)
     assert_true (nspikes2 == -1)
     assert_true (annot_bool)
-    
+
+
+@register()
+def issue499(sim):
+    """
+    Test to check that sim.end() does not erase the recorded data
+    """
+    sim.setup(min_delay=1.0, timestep = 0.1)
+    cells = sim.Population(1, sim.IF_curr_exp())
+    dcsource = sim.DCSource(amplitude=0.5, start=20, stop=80)
+    cells[0].inject(dcsource)
+    cells.record('v')
+
+    sim.run(50.0)
+    sim.end()
+    vm = cells.get_data().segments[0].filter(name="v")[0]
+    v_dc = vm[:, 0]
+    assert_true (len(v_dc)!=0)
+
 
 if __name__ == '__main__':
     from pyNN.utility import get_simulator
@@ -370,3 +388,4 @@ if __name__ == '__main__':
     test_sampling_interval(sim)
     test_mix_procedural_and_oo(sim)
     issue_449_490_491(sim)
+    issue499(sim)


### PR DESCRIPTION
Fix for issue #499.
Removes `simulator.state.clear()` from `sim.end()` for Brian.