### PR TITLE
Fixes #497: tweaks phase for NEST ACSource

### DIFF
--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -86,7 +86,7 @@ class NestCurrentSource(StandardCurrentSource):
                                               'amplitude_times': times})
             elif key in ("start", "stop"):
                 nest.SetStatus(self._device, {key: self._delay_correction(value)})
-                if key == "start":
+                if key == "start" and type(self).__name__ == "ACSource":
                     self._phase_correction(self.start, self.frequency, self.phase_given)
             elif key == "frequency":
                 nest.SetStatus(self._device, {key: value})

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -74,6 +74,11 @@ class NestCurrentSource(StandardCurrentSource):
                                               'amplitude_times': times})
             elif key in ("start", "stop"):
                 nest.SetStatus(self._device, {key: self._delay_correction(value)})
+            elif key == "phase":
+                phase_fix = ( (value*numpy.pi/180) - (2*numpy.pi*self.frequency*self.start/1000)) * 180/numpy.pi
+                phase_fix.shape = (1)
+                phase_fix = phase_fix.evaluate()[0]
+                nest.SetStatus(self._device, {key: phase_fix})
             elif not key == "amplitude_times":
                 nest.SetStatus(self._device, {key: value})
 

--- a/test/system/scenarios/test_electrodes.py
+++ b/test/system/scenarios/test_electrodes.py
@@ -400,9 +400,9 @@ def issue497(sim):
     i_t_ac1, i_amp_ac1 = acsource1._get_data()
     i_t_ac2, i_amp_ac2 = acsource2._get_data()
 
-    # test to verify that acsource1 has first calculated value as 0
+    # test to verify that acsource1 has value at t = start as 0
     assert_true (abs(i_amp_ac1[int(start/sim_dt)]) < 1e-9)
-    # test to verify that acsource2 has first calculated value as 'amplitude'
+    # test to verify that acsource2 has value at start as 'amplitude'
     assert_true (abs(i_amp_ac2[int(start/sim_dt)]-amplitude) < 1e-9)
 
 

--- a/test/system/scenarios/test_electrodes.py
+++ b/test/system/scenarios/test_electrodes.py
@@ -387,22 +387,22 @@ def issue497(sim):
     acsource1 = sim.ACSource(start=start, stop=20.0, amplitude=amplitude, offset=0.0,
                         frequency=100.0, phase=0.0)
     cells[0].inject(acsource1)
-    acsource1._record()
+    acsource1.record()
     acsource2 = sim.ACSource(start=start, stop=20.0, amplitude=amplitude, offset=0.0,
                         frequency=100.0, phase=90.0)
     cells[1].inject(acsource2)
-    acsource2._record()
+    acsource2.record()
 
     cells.record('v')
     sim.run(25.0)
     vm = cells.get_data().segments[0].filter(name="v")[0]
     sim.end()
-    i_t_ac1, i_amp_ac1 = acsource1._get_data()
-    i_t_ac2, i_amp_ac2 = acsource2._get_data()
+    i_t_ac1, i_amp_ac1 = acsource1.get_data()
+    i_t_ac2, i_amp_ac2 = acsource2.get_data()
 
     # test to verify that acsource1 has value at t = start as 0
     assert_true (abs(i_amp_ac1[int(start/sim_dt)]) < 1e-9)
-    # test to verify that acsource2 has value at start as 'amplitude'
+    # test to verify that acsource2 has value at t = start as 'amplitude'
     assert_true (abs(i_amp_ac2[int(start/sim_dt)]-amplitude) < 1e-9)
 
 

--- a/test/system/scenarios/test_electrodes.py
+++ b/test/system/scenarios/test_electrodes.py
@@ -387,18 +387,18 @@ def issue497(sim):
     acsource1 = sim.ACSource(start=start, stop=20.0, amplitude=amplitude, offset=0.0,
                         frequency=100.0, phase=0.0)
     cells[0].inject(acsource1)
-    acsource1.record()
+    acsource1._record()
     acsource2 = sim.ACSource(start=start, stop=20.0, amplitude=amplitude, offset=0.0,
                         frequency=100.0, phase=90.0)
     cells[1].inject(acsource2)
-    acsource2.record()
+    acsource2._record()
 
     cells.record('v')
     sim.run(25.0)
     vm = cells.get_data().segments[0].filter(name="v")[0]
     sim.end()
-    i_t_ac1, i_amp_ac1 = acsource1.get_data()
-    i_t_ac2, i_amp_ac2 = acsource2.get_data()
+    i_t_ac1, i_amp_ac1 = acsource1._get_data()
+    i_t_ac2, i_amp_ac2 = acsource2._get_data()
 
     # test to verify that acsource1 has first calculated value as 0
     assert_true (abs(i_amp_ac1[int(start/sim_dt)]) < 1e-9)

--- a/test/system/scenarios/test_electrodes.py
+++ b/test/system/scenarios/test_electrodes.py
@@ -368,14 +368,14 @@ def issue487(sim):
     assert_true (numpy.isclose(v_step_2_arr[0:int(step_2.times[0]/dt)], v_rest).all())
 
 
-@register(exclude=["nest"])
+@register(exclude=["brian", "neuron", "nest"])
 def issue497(sim):
     """
     This is a test to check that the specified phase for the ACSource is valid
     at the specified start time (and not, for example, at t=0 as NEST currently does)
 
-    NOTE: This test is currently excluded for NEST in the 'master' branch, as
-    the current recording feature is not presently available in 'master'
+    NOTE: This test is currently excluded for all the simulators as the final
+    current recording implementation is currently unavailable on 'master'.
     """
     sim_dt = 0.1
     sim.setup(min_delay=1.0, timestep = sim_dt)


### PR DESCRIPTION
Fixes #497 (see for details)
Tweaks the value of `phase` supplied to NEST ACSource so as to remain consistent with other simulators. The test case for this fix requires the recording of current profiles. As the final current recording implementation is currently unavailable in the 'master' branch, the test has been excluded for the time being. Tested locally to ensure it works.