### PR TITLE
Fixes #482 - Handles timestamps of StepCurrentSource for NEST

### DIFF
--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -27,6 +27,7 @@ class NestCurrentSource(StandardCurrentSource):
     def __init__(self, **parameters):
         self._device = nest.Create(self.nest_name)
         self.cell_list = []
+        self.phase_given = 0.0  # required for PR #502
         parameter_space = ParameterSpace(self.default_parameters,
                                          self.get_schema(),
                                          shape=(1,))
@@ -57,6 +58,21 @@ class NestCurrentSource(StandardCurrentSource):
             corrected = max(corrected, 0.0)
         return corrected
 
+    def _phase_correction(self, start, freq, phase):
+        """
+        Fixes #497 (PR #502)
+        Tweaks the value of phase supplied to NEST ACSource
+        so as to remain consistent with other simulators
+        """
+        phase_fix = ( (phase*numpy.pi/180) - (2*numpy.pi*freq*start/1000)) * 180/numpy.pi
+        phase_fix.shape = (1)
+        phase_fix = phase_fix.evaluate()[0]
+        nest.SetStatus(self._device, {'phase': phase_fix})
+
+    def _round_timestamp(self, value, resolution):
+        # subtraction by 1e-12 to match NEURON working
+        return round ((float(value)-1e-12)/ resolution) * resolution
+
     def set_native_parameters(self, parameters):
         parameters.evaluate(simplify=True)
         for key, value in parameters.items():
@@ -66,14 +82,25 @@ class NestCurrentSource(StandardCurrentSource):
                 numpy.append(times, 1e12)
                 amplitudes = value.value
                 numpy.append(amplitudes, amplitudes[-1])
-                if amplitudes[0] != 0:
-                    times[0] = max(times[0], state.dt)  # NEST ignores changes at time zero.
-                    # must it be dt, or would any positive value work?
-                    # this will fail if the second, third, etc. time points are also close to zero
+                ctr = next((i for i,v in enumerate(times) if v > state.dt), None) - 1
+                if ctr >= 0:
+                    times[ctr] = state.dt
+                    times = times[ctr:]
+                    amplitudes = amplitudes[ctr:]
+                for ind in range(len(times)):
+                    times[ind] = self._round_timestamp(times[ind], state.dt)
                 nest.SetStatus(self._device, {key: amplitudes,
                                               'amplitude_times': times})
             elif key in ("start", "stop"):
                 nest.SetStatus(self._device, {key: self._delay_correction(value)})
+                if key == "start" and type(self).__name__ == "ACSource":
+                    self._phase_correction(self.start, self.frequency, self.phase_given)
+            elif key == "frequency":
+                nest.SetStatus(self._device, {key: value})
+                self._phase_correction(self.start, self.frequency, self.phase_given)
+            elif key == "phase":
+                self.phase_given = value
+                self._phase_correction(self.start, self.frequency, self.phase_given)
             elif not key == "amplitude_times":
                 nest.SetStatus(self._device, {key: value})
 
@@ -81,6 +108,24 @@ class NestCurrentSource(StandardCurrentSource):
         all_params = nest.GetStatus(self._device)[0]
         return ParameterSpace(dict((k, v) for k, v in all_params.items()
                                    if k in self.get_native_names()))
+
+    def record(self):
+        self.i_multimeter = nest.Create('multimeter', params={'record_from': ['I'], 'interval' :state.dt})
+        nest.Connect(self.i_multimeter, self._device)
+
+    def get_data(self):
+        events = nest.GetStatus(self.i_multimeter)[0]['events']
+        # Similar to recording.py: NEST does not record values at
+        # the zeroth time step, so we add them here.
+        t_arr = numpy.insert(numpy.array(events['times']), 0, 0.0)
+        i_arr = numpy.insert(numpy.array(events['I']/1000.0), 0, 0.0)
+        # NEST and pyNN have different concepts of current initiation times
+        # To keep this consistent across simulators, we will have current
+        # initiating at the electrode at t_start and effect on cell at next dt
+        # This requires padding min_delay equivalent period with 0's
+        pad_length = int(state.min_delay/state.dt)
+        i_arr = numpy.insert(i_arr[:-pad_length], 0, [0]*pad_length)
+        return t_arr, i_arr
 
 
 class DCSource(NestCurrentSource, electrodes.DCSource):
@@ -129,3 +174,4 @@ class NoisyCurrentSource(NestCurrentSource, electrodes.NoisyCurrentSource):
         ('dt',    'dt')
     )
     nest_name = 'noise_generator'
+

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -79,16 +79,14 @@ class NestCurrentSource(StandardCurrentSource):
             if key == "amplitude_values":
                 assert isinstance(value, Sequence)
                 times = self._delay_correction(parameters["amplitude_times"].value)
-                numpy.append(times, 1e12)
                 amplitudes = value.value
-                numpy.append(amplitudes, amplitudes[-1])
-                ctr = next((i for i,v in enumerate(times) if v > state.dt), None) - 1
+                ctr = next((i for i,v in enumerate(times) if v > state.dt), len(times)) - 1
                 if ctr >= 0:
                     times[ctr] = state.dt
                     times = times[ctr:]
                     amplitudes = amplitudes[ctr:]
                 for ind in range(len(times)):
-                    times[ind] = self._round_timestamp(times[ind], state.dt)
+                    times[ind] = self._round_timestamp(times[ind], state.dt)                
                 nest.SetStatus(self._device, {key: amplitudes,
                                               'amplitude_times': times})
             elif key in ("start", "stop"):

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -107,24 +107,6 @@ class NestCurrentSource(StandardCurrentSource):
         return ParameterSpace(dict((k, v) for k, v in all_params.items()
                                    if k in self.get_native_names()))
 
-    def record(self):
-        self.i_multimeter = nest.Create('multimeter', params={'record_from': ['I'], 'interval' :state.dt})
-        nest.Connect(self.i_multimeter, self._device)
-
-    def get_data(self):
-        events = nest.GetStatus(self.i_multimeter)[0]['events']
-        # Similar to recording.py: NEST does not record values at
-        # the zeroth time step, so we add them here.
-        t_arr = numpy.insert(numpy.array(events['times']), 0, 0.0)
-        i_arr = numpy.insert(numpy.array(events['I']/1000.0), 0, 0.0)
-        # NEST and pyNN have different concepts of current initiation times
-        # To keep this consistent across simulators, we will have current
-        # initiating at the electrode at t_start and effect on cell at next dt
-        # This requires padding min_delay equivalent period with 0's
-        pad_length = int(state.min_delay/state.dt)
-        i_arr = numpy.insert(i_arr[:-pad_length], 0, [0]*pad_length)
-        return t_arr, i_arr
-
 
 class DCSource(NestCurrentSource, electrodes.DCSource):
     __doc__ = electrodes.DCSource.__doc__


### PR DESCRIPTION
Continuing on the discussion under issue #482 :
The sequence of steps for NEST is now as follows:
(consider `dt = min_delay = 0.1 ms`)
1) User inputs a time series, e.g.
`times = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]`
2) `_delay_correction()` will subtract `min_delay` (set to 0.0, if result is negative), so
`times = [0.0, 0.0, 0.1, 0.2, 0.3, 0.4]`
3) We now scan the time series to find the last element matching `dt`. This corresponds to the first timestamp that can be used by NEST for current injection. All prior timestamps (and corresponding amplitudes) are removed. So we have
`times = [0.1, 0.2, 0.3, 0.4]`

A thorough test case for the StepCurrentSource across all simulators will be developed for issue #512 , and thus the same is avoided here.

The fix has been tested for the issue reported for the Izhikevich model under OpenSourceBrain ([see here](https://github.com/OpenSourceBrain/IzhikevichModel/issues/6)) and found to resolve the same.