### PR TITLE
Fix for #512

### DIFF
--- a/doc/data_handling.txt
+++ b/doc/data_handling.txt
@@ -80,8 +80,8 @@ Matlab :file:`.mat` files, and HDF5. To write to a given format, we create a Neo
 
 .. doctest::
 
-    >>> from neo.io import NeoHdf5IO
-    >>> io = NeoHdf5IO(filename="my_data.h5")
+    >>> from neo.io import NixIO
+    >>> io = NixIO(filename="my_data.h5")
     >>> population.write_data(io)
 
 .. todo: check whether we need to close the `io` object.
@@ -173,6 +173,6 @@ for example SpykeViewer_ and OpenElectrophy_.
 
 
 .. _Neo: http://neuralensemble.org/neo
-.. _`variety of different file formats`: http://packages.python.org/neo/io.html#module-neo.io
+.. _`variety of different file formats`: http://neo.readthedocs.io/en/latest/io.html
 .. _SpykeViewer: http://spyke-viewer.readthedocs.org/en/0.4.0/
 .. _OpenElectrophy: http://neuralensemble.org/OpenElectrophy/

--- a/pyNN/brian/standardmodels/electrodes.py
+++ b/pyNN/brian/standardmodels/electrodes.py
@@ -48,14 +48,11 @@ class BrianCurrentSource(StandardCurrentSource):
         parameter_space = self.translate(parameter_space)
         self.set_native_parameters(parameter_space)
 
-    def _round_timestamp(self, value, resolution):
-        return int(value/resolution+0.5) * resolution
-
     def _check_step_times(self, times, amplitudes, resolution):
         # change resolution from ms to s; as per brian convention
         resolution = resolution*1e-3
         # ensure that all time stamps are non-negative
-        if not all(times>=0.0):
+        if not (times >= 0.0).all():
             raise ValueError("Step current cannot accept negative timestamps.")
         # ensure that times provided are of strictly increasing magnitudes
         dt_times = numpy.diff(times)
@@ -83,7 +80,7 @@ class BrianCurrentSource(StandardCurrentSource):
                 step_amplitudes = parameters["amplitudes"].value
                 step_times, step_amplitudes = self._check_step_times(step_times, step_amplitudes, simulator.state.dt)
                 parameters["times"].value = step_times
-                parameters["amplitudes"].value = step_amplitudes            
+                parameters["amplitudes"].value = step_amplitudes
             if isinstance(value, Sequence):
                 value = value.value
             object.__setattr__(self, name, value)

--- a/pyNN/brian/standardmodels/electrodes.py
+++ b/pyNN/brian/standardmodels/electrodes.py
@@ -48,9 +48,46 @@ class BrianCurrentSource(StandardCurrentSource):
         parameter_space = self.translate(parameter_space)
         self.set_native_parameters(parameter_space)
 
+    def _round_timestamp(self, value, resolution):
+        return int(value/resolution+0.5) * resolution
+
+    def _check_step_times(self, times, amplitudes, resolution):
+        # change resolution from ms to s; as per brian convention
+        resolution = resolution*1e-3
+        # ensure that all time stamps are non-negative
+        if not all(times>=0.0):
+            raise ValueError("Step current cannot accept negative timestamps.")
+        # ensure that times provided are of strictly increasing magnitudes
+        dt_times = numpy.diff(times)
+        if not all(dt_times>0.0):
+            raise ValueError("Step current timestamps should be monotonically increasing.")
+        # map timestamps to actual simulation time instants based on specified dt
+        for ind in range(len(times)):
+            times[ind] = self._round_timestamp(times[ind], resolution)
+        # remove duplicate timestamps, and corresponding amplitudes, after mapping
+        step_times = []
+        step_amplitudes = []
+        for ts0, amp0, ts1 in zip(times, amplitudes, times[1:]):
+            if ts0 != ts1:
+                step_times.append(ts0)
+                step_amplitudes.append(amp0)
+        step_times.append(times[-1])
+        step_amplitudes.append(amplitudes[-1])
+        return step_times, step_amplitudes
+
     def set_native_parameters(self, parameters):
         parameters.evaluate(simplify=True)
         for name, value in parameters.items():
+            if name == "amplitudes": # key used only by StepCurrentSource
+                print "Times Before = ", parameters["times"].value
+                print "Amps Before = ", parameters["amplitudes"].value
+                step_times = parameters["times"].value
+                step_amplitudes = parameters["amplitudes"].value
+                step_times, step_amplitudes = self._check_step_times(step_times, step_amplitudes, simulator.state.dt)
+                parameters["times"].value = step_times
+                parameters["amplitudes"].value = step_amplitudes
+                print "Times After = ", parameters["times"].value
+                print "Amps After = ", parameters["amplitudes"].value
             if isinstance(value, Sequence):
                 value = value.value
             object.__setattr__(self, name, value)

--- a/pyNN/brian/standardmodels/electrodes.py
+++ b/pyNN/brian/standardmodels/electrodes.py
@@ -79,15 +79,11 @@ class BrianCurrentSource(StandardCurrentSource):
         parameters.evaluate(simplify=True)
         for name, value in parameters.items():
             if name == "amplitudes": # key used only by StepCurrentSource
-                print "Times Before = ", parameters["times"].value
-                print "Amps Before = ", parameters["amplitudes"].value
                 step_times = parameters["times"].value
                 step_amplitudes = parameters["amplitudes"].value
                 step_times, step_amplitudes = self._check_step_times(step_times, step_amplitudes, simulator.state.dt)
                 parameters["times"].value = step_times
-                parameters["amplitudes"].value = step_amplitudes
-                print "Times After = ", parameters["times"].value
-                print "Amps After = ", parameters["amplitudes"].value
+                parameters["amplitudes"].value = step_amplitudes            
             if isinstance(value, Sequence):
                 value = value.value
             object.__setattr__(self, name, value)

--- a/pyNN/nest/electrodes.py
+++ b/pyNN/nest/electrodes.py
@@ -46,10 +46,6 @@ class NestCurrentSource(BaseCurrentSource):
             corrected = max(corrected, 0.0)
         return corrected
 
-    def _round_timestamp(self, value, resolution):
-        # subtraction by 1e-12 to match NEURON working
-        return round ((float(value)-1e-12)/ resolution) * resolution
-
     def record(self):
         self.i_multimeter = nest.Create('multimeter', params={'record_from': ['I'], 'interval': state.dt})
         nest.Connect(self.i_multimeter, self._device)
@@ -74,18 +70,18 @@ def native_electrode_type(model_name):
     Return a new NativeElectrodeType subclass.
     """
     assert isinstance(model_name, str)
-    default_parameters, default_initial_values = get_defaults(model_name)  
+    default_parameters, default_initial_values = get_defaults(model_name)
     return type(model_name,
                (NativeElectrodeType,),
                 {'nest_name': model_name,
                  'default_parameters': default_parameters,
                  'default_initial_values': default_initial_values,
                 })
-    
+
 
 # Should be usable with any NEST current generator
 class NativeElectrodeType(NestCurrentSource):
-    
+
     _is_computed = True
     _is_playable = True
 

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -88,7 +88,7 @@ class NestStandardCurrentSource(NestCurrentSource, StandardCurrentSource):
         times = self._delay_correction(times)
         # find the last element <= dt (we find >dt and then go one element back)
         # this corresponds to the first timestamp that can be used by NEST for current injection
-        ctr = next((i for i,v in enumerate(times) if v > state.dt), len(times)) - 1
+        ctr = numpy.searchsorted(times, state.dt, side="right") - 1
         if ctr >= 0:
             times[ctr] = state.dt
             times = times[ctr:]

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -92,7 +92,7 @@ class NestCurrentSource(StandardCurrentSource):
         times = self._delay_correction(times)
         # find the last element <= dt (we find >dt and then go one element back)
         # this corresponds to the first timestamp that can be used by NEST for current injection
-        ctr = (v > state.dt).nonzero()[0][0] - 1
+        ctr = next((i for i,v in enumerate(times) if v > state.dt), len(times)) - 1
         if ctr >= 0:
             times[ctr] = state.dt
             times = times[ctr:]

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -97,7 +97,7 @@ class NestStandardCurrentSource(NestCurrentSource, StandardCurrentSource):
         for ind in range(len(times)):
             times[ind] = self._round_timestamp(times[ind], resolution)
         # remove duplicate timestamps, and corresponding amplitudes, after mapping
-        step_times, step_indices = np.unique(times[::-1], return_index=True)
+        step_times, step_indices = numpy.unique(times[::-1], return_index=True)
         step_times = step_times.tolist()
         step_indices = len(times)-step_indices-1
         step_amplitudes = [amplitudes[i] for i in step_indices]

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -119,15 +119,11 @@ class NestCurrentSource(StandardCurrentSource):
         for key, value in parameters.items():
             if key == "amplitude_values":
                 assert isinstance(value, Sequence)
-                print "Times Before = ", parameters["amplitude_times"].value
-                print "Amps Before = ", parameters["amplitude_values"].value
                 step_times = parameters["amplitude_times"].value
                 step_amplitudes = parameters["amplitude_values"].value
                 step_times, step_amplitudes = self._check_step_times(step_times, step_amplitudes, state.dt)
                 parameters["amplitude_times"].value = step_times
-                parameters["amplitude_values"].value = step_amplitudes
-                print "Times After = ", parameters["amplitude_times"].value
-                print "Amps After = ", parameters["amplitude_values"].value
+                parameters["amplitude_values"].value = step_amplitudes                
                 nest.SetStatus(self._device, {key: step_amplitudes,
                                               'amplitude_times': step_times})
             elif key in ("start", "stop"):

--- a/pyNN/neuron/standardmodels/electrodes.py
+++ b/pyNN/neuron/standardmodels/electrodes.py
@@ -117,15 +117,11 @@ class NeuronCurrentSource(StandardCurrentSource):
         parameters.evaluate(simplify=True)
         for name, value in parameters.items():
             if name == "amplitudes": # key used only by StepCurrentSource
-                print "Times Before = ", parameters["times"].value
-                print "Amps Before = ", parameters["amplitudes"].value
                 step_times = parameters["times"].value
                 step_amplitudes = parameters["amplitudes"].value
                 step_times, step_amplitudes = self._check_step_times(step_times, step_amplitudes, simulator.state.dt)
                 parameters["times"].value = step_times
-                parameters["amplitudes"].value = step_amplitudes
-                print "Times After = ", parameters["times"].value
-                print "Amps After = ", parameters["amplitudes"].value
+                parameters["amplitudes"].value = step_amplitudes                
             if isinstance(value, Sequence):  # this shouldn't be necessary, but seems to prevent a segfault
                 value = value.value
             object.__setattr__(self, name, value)

--- a/pyNN/neuron/standardmodels/electrodes.py
+++ b/pyNN/neuron/standardmodels/electrodes.py
@@ -88,12 +88,9 @@ class NeuronCurrentSource(StandardCurrentSource):
 
             self._h_amplitudes.play(iclamp._ref_amp, self._h_times)
 
-    def _round_timestamp(self, value, resolution):
-        return int(value/resolution+0.5) * resolution
-
     def _check_step_times(self, times, amplitudes, resolution):
         # ensure that all time stamps are non-negative
-        if not all(times>=0.0):
+        if not (times >= 0.0).all():
             raise ValueError("Step current cannot accept negative timestamps.")
         # ensure that times provided are of strictly increasing magnitudes
         dt_times = numpy.diff(times)
@@ -121,7 +118,7 @@ class NeuronCurrentSource(StandardCurrentSource):
                 step_amplitudes = parameters["amplitudes"].value
                 step_times, step_amplitudes = self._check_step_times(step_times, step_amplitudes, simulator.state.dt)
                 parameters["times"].value = step_times
-                parameters["amplitudes"].value = step_amplitudes                
+                parameters["amplitudes"].value = step_amplitudes
             if isinstance(value, Sequence):  # this shouldn't be necessary, but seems to prevent a segfault
                 value = value.value
             object.__setattr__(self, name, value)

--- a/pyNN/standardmodels/__init__.py
+++ b/pyNN/standardmodels/__init__.py
@@ -210,6 +210,8 @@ class StandardCurrentSource(StandardModelType, models.BaseCurrentSource):
     def get_native_parameters(self):
         raise NotImplementedError
 
+    def _round_timestamp(self, value, resolution):
+        return int(value/resolution+0.5) * resolution
 
 class ModelNotAvailable(object):
     """Not available for this simulator."""

--- a/test/system/scenarios/test_electrodes.py
+++ b/test/system/scenarios/test_electrodes.py
@@ -429,7 +429,7 @@ def issue_465_474(sim):
     i_noise = noise.get_data()
     i_step = step.get_data()
 
-    # test for length of recorded current traces    
+    # test for length of recorded current traces
     assert_true (len(i_ac) == (int(simtime/sim_dt)+1) == len(v_ac))
     assert_true (len(i_dc) == int(simtime/sim_dt)+1 == len(v_dc))
     assert_true (len(i_noise) == int(simtime/sim_dt)+1 == len(v_noise))

--- a/test/system/scenarios/test_electrodes.py
+++ b/test/system/scenarios/test_electrodes.py
@@ -1,6 +1,6 @@
 
 
-from nose.tools import assert_equal, assert_true, assert_false
+from nose.tools import assert_equal, assert_true, assert_false, assert_raises
 from numpy.testing import assert_array_equal
 import quantities as pq
 import numpy
@@ -448,26 +448,16 @@ def issue512(sim):
     sim.setup(timestep=dt, min_delay=dt)
     cells = sim.Population(1, sim.IF_curr_exp(v_thresh=-55.0, tau_refrac=5.0, v_rest=-60.0))
     # 1.1) Negative time value
-    flag = 0
-    try:
-        step = sim.StepCurrentSource(times=[0.4, -0.6, 0.8],
-                                     amplitudes=[0.5, -0.5, 0.5])
-    except ValueError:
-        flag = 1
-    assert_true (flag == 1)
+    assert_raises(ValueError, sim.StepCurrentSource,
+                  times=[0.4, -0.6, 0.8], amplitudes=[0.5, -0.5, 0.5])
     # 1.2) Time values not monotonically increasing
-    flag = 0
-    try:
-        step = sim.StepCurrentSource(times=[0.4, 0.2, 0.8],
-                                     amplitudes=[0.5, -0.5, 0.5])
-    except ValueError:
-        flag = 1
-    assert_true (flag == 1)
+    assert_raises(ValueError, sim.StepCurrentSource,
+                  times=[0.4, 0.2, 0.8], amplitudes=[0.5, -0.5, 0.5])
     # 1.3) Check mapping of time values and removal of duplicates
     step = sim.StepCurrentSource(times=[0.41, 0.42, 0.85],
-                                     amplitudes=[0.5, -0.5, 0.5])
-    assert_true (get_len(step.times) == 2)
-    assert_true (get_len(step.amplitudes) == 2)
+                                 amplitudes=[0.5, -0.5, 0.5])
+    assert_equal(get_len(step.times), 2)
+    assert_equal(get_len(step.amplitudes), 2)
     if "pyNN.brian" in str(sim):
         # Brian requires time in seconds (s)
         assert_true (abs(step.times[0]-0.4*1e-3) < 1e-9)
@@ -488,33 +478,23 @@ def issue512(sim):
             assert_true (abs(step.times[1]-0.8) < 1e-9)
         else: # neuron
             assert_true (abs(step.times[0]-0.4) < 1e-9)
-            assert_true (abs(step.times[1]-0.9) < 1e-9)            
+            assert_true (abs(step.times[1]-0.9) < 1e-9)
 
     # 2) dt = 0.01 ms, min_delay = 0.01 ms
     dt = 0.01
     sim.setup(timestep=dt, min_delay=dt)
     cells = sim.Population(1, sim.IF_curr_exp(v_thresh=-55.0, tau_refrac=5.0, v_rest=-60.0))
     # 2.1) Negative time value
-    flag = 0
-    try:
-        step = sim.StepCurrentSource(times=[0.4, -0.6, 0.8],
-                                     amplitudes=[0.5, -0.5, 0.5])
-    except ValueError:
-        flag = 1
-    assert_true (flag == 1)
+    assert_raises(ValueError, sim.StepCurrentSource,
+                  times=[0.4, -0.6, 0.8], amplitudes=[0.5, -0.5, 0.5])
     # 2.2) Time values not monotonically increasing
-    flag = 0
-    try:
-        step = sim.StepCurrentSource(times=[0.5, 0.4999, 0.8],
-                                     amplitudes=[0.5, -0.5, 0.5])
-    except ValueError:
-        flag = 1
-    assert_true (flag == 1)
+    assert_raises(ValueError, sim.StepCurrentSource,
+                  times=[0.5, 0.4999, 0.8], amplitudes=[0.5, -0.5, 0.5])
     # 2.3) Check mapping of time values and removal of duplicates
     step = sim.StepCurrentSource(times=[0.451, 0.452, 0.85],
-                                     amplitudes=[0.5, -0.5, 0.5])
-    assert_true (get_len(step.times) == 2)
-    assert_true (get_len(step.amplitudes) == 2)
+                                 amplitudes=[0.5, -0.5, 0.5])
+    assert_equal(get_len(step.times), 2)
+    assert_equal(get_len(step.amplitudes), 2)
     if "pyNN.brian" in str(sim):
         # Brian requires time in seconds (s)
         assert_true (abs(step.times[0]-0.45*1e-3) < 1e-9)
@@ -536,7 +516,6 @@ def issue512(sim):
         else: # neuron
             assert_true (abs(step.times[0]-0.45) < 1e-9)
             assert_true (abs(step.times[1]-0.85) < 1e-9)
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fix attempts to ensure that the StepCurrentSource times are handled similarly by all the simulators. The details are as discussed in #512 .

@apdavison : The test case needed as much as work as the fix itself here (lots of simulator specific checks). Do take a look and let me know if it could have been done better. Was the first time that I actually wanted an error raised as a check for proper functioning, and so not sure if this was the best approach (suggestions on StackOverflow seemed more involved).