### PR TITLE
Simplify interaction of random number generators and lazyarray

### DIFF
--- a/pyNN/connectors.py
+++ b/pyNN/connectors.py
@@ -614,12 +614,12 @@ class FixedNumberConnector(MapConnector):
         self.rng = _get_rng(rng)
 
     def _rng_uniform_int_exclude(self, n, size, exclude):
-        res = self.rng.next(n, 'uniform_int', {"low": 0, "high": size}, mask_local=False)
+        res = self.rng.next(n, 'uniform_int', {"low": 0, "high": size}, mask=None)
         logger.debug("RNG0 res=%s" % res)
         idx = numpy.where(res == exclude)[0]
         logger.debug("RNG1 exclude=%d, res=%s idx=%s" % (exclude, res, idx))
         while idx.size > 0:
-            redrawn = self.rng.next(idx.size, 'uniform_int', {"low": 0, "high": size}, mask_local=False)
+            redrawn = self.rng.next(idx.size, 'uniform_int', {"low": 0, "high": size}, mask=None)
             res[idx] = redrawn
             idx = idx[numpy.where(res == exclude)[0]]
             logger.debug("RNG2 exclude=%d redrawn=%s res=%s idx=%s" % (exclude, redrawn, res, idx))
@@ -680,7 +680,7 @@ class FixedNumberPostConnector(FixedNumberConnector):
                 if not self.allow_self_connections and projection.pre == projection.post:
                     targets = self._rng_uniform_int_exclude(n, projection.post.size, source_index)
                 else:
-                    targets = self.rng.next(n, 'uniform_int', {"low": 0, "high": projection.post.size}, mask_local=False)
+                    targets = self.rng.next(n, 'uniform_int', {"low": 0, "high": projection.post.size}, mask=None)
             else:
                 all_cells = numpy.arange(projection.post.size)
                 if not self.allow_self_connections and projection.pre == projection.post:
@@ -766,7 +766,7 @@ class FixedNumberPreConnector(FixedNumberConnector):
                 def build_source_masks(mask=None):
                     n_pre = self._get_num_pre(projection.post.size, mask)
                     for n in n_pre:
-                        sources = self.rng.next(n, 'uniform_int', {"low": 0, "high": projection.pre.size}, mask_local=False)
+                        sources = self.rng.next(n, 'uniform_int', {"low": 0, "high": projection.pre.size}, mask=None)
                         assert sources.size == n
                         yield sources
             else:
@@ -1031,7 +1031,7 @@ class FixedTotalNumberConnector(FixedNumberConnector):
         for i in range(num_conns_on_vp[rank]):
             source_index = self.rng.next(1, 'uniform_int',
                                          {"low": 0, "high": projection.pre.size},
-                                         mask_local=False)[0]
+                                         mask=None)[0]
             target_index = self.rng.choice(possible_targets, size=1)[0]
             connections[target_index].append(source_index)
 

--- a/pyNN/parameters.py
+++ b/pyNN/parameters.py
@@ -86,14 +86,13 @@ class LazyArray(larray):
         if isinstance(self.base_value, RandomDistribution) and self.base_value.rng.parallel_safe:
             if mask is None:
                 for j in column_indices:
-                    yield self._apply_operations(self.base_value.next(self.nrows, mask_local=False),
-                                                 (slice(None), j))
+                    yield self._partially_evaluate((slice(None), j), simplify=True)
             else:
                 column_indices = numpy.arange(self.ncols)
                 for j, local in zip(column_indices, mask):
-                    col = self.base_value.next(self.nrows, mask_local=False)
+                    col = self._partially_evaluate((slice(None), j), simplify=True)
                     if local:
-                        yield self._apply_operations(col, (slice(None), j))
+                        yield col
         else:
             for j in column_indices:
                 yield self._partially_evaluate((slice(None), j), simplify=True)

--- a/pyNN/recording/__init__.py
+++ b/pyNN/recording/__init__.py
@@ -85,7 +85,7 @@ def gather_blocks(data, ordered=True):
     # for now, use gather_dict, which will probably be slow. Can optimize later
     D = {mpi_comm.rank: data}
     D = gather_dict(D)
-    blocks = D.values()
+    blocks = list(D.values())
     merged = data
     if mpi_comm.rank == MPI_ROOT:    
         merged = blocks[0]


### PR DESCRIPTION
There are two changes here:
(1) previously, a random number generator with `parallel_safe=False` would always draw a reduced number of values when run with >1 MPI processes, according to the number of processes, unless the `mask_local` parameter was set to `False`. Now, a mask must be explicitly provided if you want to draw a reduced number of values (i.e. only those values consumed on that node), `mask` (renamed from `mask_local`) is either an array, or None, and can no longer take the value `False`.  
(2) moved the lazyarray behaviour for `RandomDistribution` from the lazyarray package to PyNN, to keep all the rng-related logic in one place.