### PR TITLE
Fixed to avoid float-valued list indices error

### DIFF
--- a/examples/Potjans2014/plotting.py
+++ b/examples/Potjans2014/plotting.py
@@ -16,7 +16,7 @@ def show_raster_bars(t_start, t_stop, n_rec, frac_to_plot, path):
     pop_list = ['E', 'I'] 
 
     for i in range(8):
-        layer = i / 2
+        layer = int(i / 2)
         pop = i % 2
         filestart = path + 'spikes_' + str(layer_list[layer]) + '_' + str(pop_list[pop]) + '*'
         filelist = glob.glob(filestart)
@@ -43,7 +43,7 @@ def show_raster_bars(t_start, t_stop, n_rec, frac_to_plot, path):
     id_count = 0
     print("Mean rates")
     for i in range(8)[::-1]:
-        layer = i / 2
+        layer = int(i / 2)
         pop = i % 2
         rate = 0.0
         t_spikes = spikes[i][:, 0]


### PR DESCRIPTION
`layer` must be integer valued or else `layer_list[layer]` will throw an exception, at least in versions of Python the don't coerce floats to ints automatically.  