### PR TITLE
Temporary fix for MPI bug in Projection.get

### DIFF
--- a/pyNN/common/projections.py
+++ b/pyNN/common/projections.py
@@ -255,7 +255,7 @@ class Projection(object):
 
     # --- Methods for writing/reading information to/from file. ---------------
 
-    def get(self, attribute_names, format, gather=True, with_address=True,
+    def get(self, attribute_names, format, gather='all', with_address=True,
             multiple_synapses='sum'):
         """
         Get the values of a given attribute (weight or delay) for all

--- a/pyNN/neuron/cells.py
+++ b/pyNN/neuron/cells.py
@@ -607,5 +607,5 @@ class VectorSpikeSource(hclass(h.VecStim)):
         end = self._spike_times.indwhere(">", h.t)
         if end > 0:
             self._spike_times.remove(0, end - 1)  # range is inclusive
-
-    
+        else:
+            self._spike_times.resize(0)


### PR DESCRIPTION
This is a rather subtle bug. With MPI enabled it fails with error "File "projections.py", line 352, in get() : return values[0] : IndexError: list index out of range"

The problem is that if gather is not 'all', on line 352 the method tries to address the array which is empty on nodes with rank != 0. Another solution would be to put that statement inside the preceding if-block and merge that if block with the enclosing one, so an empty 'values' is returned on nodes with rank != 0.