### PR TITLE
Bugfix: past spikes were not cleared in NEURON VectorSpikeSource

### DIFF
--- a/pyNN/neuron/cells.py
+++ b/pyNN/neuron/cells.py
@@ -609,3 +609,5 @@ class VectorSpikeSource(hclass(h.VecStim)):
             self._spike_times.remove(0, end - 1)  # range is inclusive
         else:
             self._spike_times.resize(0)
+        # Vector is resized -> restart VecStim.play() to fix indexing
+        self.play(self._spike_times)

--- a/pyNN/neuron/cells.py
+++ b/pyNN/neuron/cells.py
@@ -607,5 +607,5 @@ class VectorSpikeSource(hclass(h.VecStim)):
         end = self._spike_times.indwhere(">", h.t)
         if end > 0:
             self._spike_times.remove(0, end - 1)  # range is inclusive
-
-    
+        else:
+            self._spike_times.resize(0)


### PR DESCRIPTION
This fixed a bug for me when writing out data during a simulation. Without this line, spikes were not cleared and in `recorder._get_current_segment` an error was raised when constructing a `neo.SpikeTrain` containing spike times <= recording start time.