### PR TITLE
Update brian imports to use brian2

### DIFF
--- a/pyNN/brian/__init__.py
+++ b/pyNN/brian/__init__.py
@@ -6,7 +6,7 @@ Brian implementation of the PyNN API.
 """
 
 import logging
-import brian
+import brian2
 from pyNN import common, space
 from pyNN.common.control import DEFAULT_MAX_DELAY, DEFAULT_TIMESTEP, DEFAULT_MIN_DELAY
 from pyNN.connectors import *

--- a/pyNN/brian/cells.py
+++ b/pyNN/brian/cells.py
@@ -8,7 +8,7 @@ Definition of cell classes for the brian module.
 
 
 import numpy
-import brian
+import brian2
 from pyNN.parameters import Sequence, simplify
 from pyNN import errors
 from . import simulator

--- a/pyNN/brian/projections.py
+++ b/pyNN/brian/projections.py
@@ -6,8 +6,8 @@
 from itertools import chain
 from collections import defaultdict
 import numpy
-import brian
-from brian import uS, nA, mV, ms
+import brian2
+from brian2 import uS, nA, mV, ms
 from pyNN import common
 from pyNN.standardmodels.synapses import TsodyksMarkramSynapse
 from pyNN.core import is_listlike

--- a/pyNN/brian/recording.py
+++ b/pyNN/brian/recording.py
@@ -7,7 +7,7 @@
 import logging
 import numpy
 import quantities as pq
-import brian
+import brian2
 from pyNN.core import is_listlike
 from pyNN import recording
 from . import simulator

--- a/pyNN/brian/simulator.py
+++ b/pyNN/brian/simulator.py
@@ -21,7 +21,7 @@ modules.
 """
 
 import logging
-import brian
+import brian2
 import numpy
 from pyNN import common
 

--- a/pyNN/brian/standardmodels/cells.py
+++ b/pyNN/brian/standardmodels/cells.py
@@ -7,8 +7,8 @@ Standard cells for the Brian module.
 """
 
 from copy import deepcopy
-import brian
-from brian import mV, ms, nF, nA, uS, Hz, nS
+import brian2
+from brian2 import mV, ms, nF, nA, uS, Hz, nS
 from pyNN.standardmodels import cells, build_translations
 from ..cells import (ThresholdNeuronGroup, SpikeGeneratorGroup, PoissonGroup,
                      BiophysicalNeuronGroup, AdaptiveNeuronGroup, AdaptiveNeuronGroup2,

--- a/pyNN/brian/standardmodels/electrodes.py
+++ b/pyNN/brian/standardmodels/electrodes.py
@@ -14,8 +14,8 @@ Classes:
 
 import logging
 import numpy
-import brian
-from brian import ms, nA, Hz, network_operation, amp as ampere
+import brian2
+from brian2 import ms, nA, Hz, network_operation, amp as ampere
 from pyNN.standardmodels import electrodes, build_translations, StandardCurrentSource
 from pyNN.parameters import ParameterSpace, Sequence
 from .. import simulator

--- a/pyNN/brian/standardmodels/synapses.py
+++ b/pyNN/brian/standardmodels/synapses.py
@@ -7,7 +7,7 @@ Standard cells for the Brian module.
 """
 
 import logging
-from brian import ms
+from brian2 import ms
 from pyNN.standardmodels import synapses, build_translations
 from ..simulator import state
 

--- a/test/unittests/test_brian.py
+++ b/test/unittests/test_brian.py
@@ -1,6 +1,6 @@
 try:
     import pyNN.brian as sim
-    import brian
+    import brian2
 except ImportError:
     brian = False
 try:


### PR DESCRIPTION
All the brian documentation says `import brian2`, so that's what we
should use too.

https://brian2.readthedocs.io/en/stable/resources/tutorials/1-intro-to-brian-neurons.html