### PR TITLE
Modification in convergent_connect to speed up the building of connections

### DIFF
--- a/pyNN/nest/projections.py
+++ b/pyNN/nest/projections.py
@@ -122,6 +122,26 @@ class Projection(common.Projection):
         self._sources = [cid[0] for cid in nest.GetConnections(synapse_model=self.nest_synapse_model,
                                                                synapse_label=self.nest_synapse_label)]
 
+    
+    def _update_syn_params(self, syn_dict, connection_parameters, presynaptic_indices):
+        """
+        Update the paramaters to be passed in the nest connect method with the connection parameters specific to the synapse type
+        `syn_dict`              -- a dictionary containing parameters of the connection that this function updates with the connection parameters specific to the synapse type
+        `connection_parameters` -- a dictionary containing the parameters of the connections that are specific to the synapse type
+        `presynaptic_indices`          -- a 1D array containing the ID of the pre-synaptic cells
+        """
+        # Set connection parameters other than weight and delay
+        if connection_parameters:
+            for name, value in connection_parameters.items():
+                if name not in self._common_synapse_property_names:
+                    value = make_sli_compatible(value)
+                    if isinstance(value, numpy.ndarray):
+                        # the str() is to work around a bug handling unicode names in SetStatus in NEST 2.4.1 when using Python 2
+                        syn_dict.update({str(name):numpy.array([value.tolist()])})
+                    else:
+                        syn_dict.update({str(name):value})
+        return syn_dict
+
     def _convergent_connect(self, presynaptic_indices, postsynaptic_index,
                             **connection_parameters):
         """
@@ -141,6 +161,8 @@ class Projection(common.Projection):
             'model': self.nest_synapse_model,
             'synapse_label': self.nest_synapse_label,
         }
+        syn_dict_0 = {}
+        additional_syn_dict={}
 
         weights = connection_parameters.pop('weight')
         if self.receptor_type == 'inhibitory' and self.post.conductance_based:
@@ -155,8 +177,19 @@ class Projection(common.Projection):
             weights *= self.post.celltype.receptor_scale                                      # needed for the Izhikevich model
         delays = connection_parameters.pop('delay')
 
+        # Clean the connection parameters
+        connection_parameters.pop('tau_minus', None)  # TODO: set tau_minus on the post-synaptic cells
+        connection_parameters.pop('dendritic_delay_fraction', None)
+        connection_parameters.pop('w_min_always_zero_in_NEST', None)
+        # Those parameters can't be setup through Connect. They will be setup later with SetStatus.
+        if "init_flag" in connection_parameters.keys():
+            additional_syn_dict["init_flag"] = connection_parameters.pop("init_flag")
+        if "synapse_id" in connection_parameters.keys():
+            additional_syn_dict["synapse_id"] = connection_parameters.pop("synapse_id")
+
         # Create connections, with weights and delays
         # Setting other connection parameters is done afterwards
+
         if postsynaptic_cell.celltype.standard_receptor_type:
             try:
                 if not numpy.isscalar(weights):
@@ -174,10 +207,66 @@ class Projection(common.Projection):
                         raise NotImplementedError()
                     syn_dict.update({'tau_psc': numpy.array([[nest.GetStatus([postsynaptic_cell], param_name)[0]] * len(presynaptic_cells.astype(int).tolist())])})
 
-                nest.Connect(presynaptic_cells.astype(int).tolist(),
-                             [int(postsynaptic_cell)],
+                #We will need to use the GetConnections function only if there are some others connection parameters than weights and delays to set,
+                #and if the names of the common synapse properties haven't been computed yet.
+                if self._common_synapse_property_names is None:
+
+
+                    #Only the weight and delay parameters are set when building these connectionis, the other parameters will be set using the nest SetStatus function
+                    nest.Connect(presynaptic_cells.astype(int).tolist(),
+                                 [int(postsynaptic_cell)],
+                                 'all_to_all',
+                                 syn_dict)
+
+
+                    # Book-keeping
+                    self._sources.extend(presynaptic_cells)
+
+                    #The common synapse properties are identified by inspecting which defaults connection parameters have not been set by Nest when the connection was built
+                    self._identify_common_synapse_properties()
+
+                    #The connection that was built is retrieved so that we can setup some additional parameters through the nest SetStatus function
+                    connections = nest.GetConnections(source=presynaptic_cells.astype(int).tolist(),
+                                    target=[int(postsynaptic_cell)],
+                                    synapse_model=self.nest_synapse_model,
+                                    synapse_label=self.nest_synapse_label)
+                    sort_indices = numpy.argsort(presynaptic_cells)
+
+                    #We setup these additional parameters to the connection using the nest SetStatus function.
+                    for name, value in connection_parameters.items():
+                        if name not in self._common_synapse_property_names:
+                            value = make_sli_compatible(value)
+                            if isinstance(value, numpy.ndarray):
+                                # the str() is to work around a bug handling unicode names in SetStatus in NEST 2.4.1 when using Python 2
+                                nest.SetStatus(connections, str(name), value[sort_indices].tolist())
+                            else:
+                                nest.SetStatus(connections, str(name), value)
+                        #The parameters corresponding to common synapse properties are set separately
+                        else:
+                            self._set_common_synapse_property(name, value)
+
+
+                else:
+                    #Update the dictionary with the addional connection parameters
+                    syn_dict = self._update_syn_params(syn_dict, connection_parameters, numpy.argsort(presynaptic_indices))
+
+                    #Build all the connections and set all the parameters directly
+                    nest.Connect(presynaptic_cells.astype(int).tolist(),
+                            [int(postsynaptic_cell)],
                              'all_to_all',
                              syn_dict)
+
+                    # Book-keeping
+                    self._sources.extend(presynaptic_cells.astype(int).tolist())
+
+                    #If the common synapse properties have not been identified yet (i.e. no additional connection parameters were provided), this identifies them and sets them
+                    if self._common_synapse_property_names is None:
+                        self._identify_common_synapse_properties()
+
+                    for name, value in connection_parameters.items():
+                        if name in self._common_synapse_property_names:
+                            self._set_common_synapse_property(name, value)
+
             except nest.kernel.NESTError as e:
                 errmsg = "%s. presynaptic_cells=%s, postsynaptic_cell=%s, weights=%s, delays=%s, synapse model='%s'" % (
                             e, presynaptic_cells, postsynaptic_cell,
@@ -189,48 +278,74 @@ class Projection(common.Projection):
                 weights = repeat(weights)
             if numpy.isscalar(delays):
                 delays = repeat(delays)
-            for pre, w, d in zip(presynaptic_cells, weights, delays):
+
+            for i, (pre, w, d) in enumerate(zip(presynaptic_cells, weights, delays)):
+                connection_parameters_i={}
                 syn_dict.update({'weight': w, 'delay': d, 'receptor_type': receptor_type})
                 if 'tsodyks' in self.nest_synapse_model:
                    syn_dict.update({'tau_psc': numpy.array([[nest.GetStatus([postsynaptic_cell], param_name)[0]] * len(presynaptic_cells.astype(int).tolist())])})
 
-                nest.Connect([pre], [postsynaptic_cell], 'one_to_one', syn_dict)
+                for name, value in connection_parameters.items():
+                    if isinstance(value, numpy.ndarray):
+                        connection_parameters_i[name]=value[i]
+                    else:
+                        connection_parameters_i[name]=value
+
+                if self._common_synapse_property_names is None:
+                    nest.Connect([pre], [postsynaptic_cell], 'one_to_one', syn_dict)
 
 
-        # Book-keeping
-        self._connections = None  # reset the caching of the connection list, since this will have to be recalculated
-        self._sources.extend(presynaptic_cells)
+                    self._sources.extend(presynaptic_cells.astype(int).tolist())
 
-        # Clean the connection parameters
-        connection_parameters.pop('tau_minus', None)  # TODO: set tau_minus on the post-synaptic cells
-        connection_parameters.pop('dendritic_delay_fraction', None)
-        connection_parameters.pop('w_min_always_zero_in_NEST', None)
+                    if self._common_synapse_property_names is None:
+                        self._identify_common_synapse_properties()
 
-        # We need to distinguish between common synapse parameters and local ones
-        # We just get the parameters of the first connection (is there an easier way?)
-        if self._common_synapse_property_names is None:
-            self._identify_common_synapse_properties()
+                    syn_dict=self._update_syn_params(syn_dict,connection_parameters_i,numpy.argsort(presynaptic_indices))
 
-        # Set connection parameters other than weight and delay
-        if connection_parameters:
-            #logger.debug(connection_parameters)
-            sort_indices = numpy.argsort(presynaptic_cells)
+                    sample_connection = nest.GetConnections(source=[int(pre)],
+                                    target=[int(postsynaptic_cell)],
+                                    synapse_model=self.nest_synapse_model,
+                                    synapse_label=self.nest_synapse_label)
+
+                    for name, value in connection_parameters_i.items():
+                        if name not in self._common_synapse_property_names:
+                            value = make_sli_compatible(value)
+                            nest.SetStatus(sample_connection, str(name), value)
+                        else:
+                            self._set_common_synapse_property(name, value)
+
+                else:
+                    syn_dict=self._update_syn_params(syn_dict,connection_parameters_i,numpy.argsort(presynaptic_indices))
+
+                    nest.Connect([pre], [postsynaptic_cell], 'one_to_one', syn_dict)
+                    self._sources.extend(presynaptic_cells.astype(int).tolist())
+
+                    for name, value in connection_parameters_i.items():
+                        if name in self._common_synapse_property_names:
+                            self._set_common_synapse_property(name, value)
+
+        
+        #Setup the additional connection parameters than can't be set directly with the nest Connect function
+        if additional_syn_dict:
             connections = nest.GetConnections(source=numpy.unique(presynaptic_cells.astype(int)).tolist(),
                                               target=[int(postsynaptic_cell)],
                                               synapse_model=self.nest_synapse_model,
                                               synapse_label=self.nest_synapse_label)
-            for name, value in connection_parameters.items():
-                if name not in self._common_synapse_property_names:
-                    value = make_sli_compatible(value)
-                    #logger.debug("Setting %s=%s for connections %s" % (name, value, connections))
-                    if isinstance(value, numpy.ndarray):
-                        # the str() is to work around a bug handling unicode names in SetStatus in NEST 2.4.1 when using Python 2
-                        nest.SetStatus(connections, str(name), value[sort_indices].tolist())
-                    else:
-                        nest.SetStatus(connections, str(name), value)
-                else:
-                    self._set_common_synapse_property(name, value)
 
+            for name, value in additional_syn_dict.items():
+                    if name not in self._common_synapse_property_names:
+                        value = make_sli_compatible(value)
+                        #logger.debug("Setting %s=%s for connections %s" % (name, value, connections))
+                        if isinstance(value, numpy.ndarray):
+                            # the str() is to work around a bug handling unicode names in SetStatus in NEST 2.4.1 when using Python 2
+                            nest.SetStatus(connections, str(name), value[sort_indices].tolist())
+                        else:
+                            nest.SetStatus(connections, str(name), value)
+                    else:
+                        self._set_common_synapse_property(name, value)
+        
+        self._connections = None  # reset the caching of the connection list, since this will have to be recalculated
+                        
     def _identify_common_synapse_properties(self):
         """
             Use the connection between the sample indices to distinguish


### PR DESCRIPTION
We noticed that since NEST 2.16, the nest GetConnections function takes a lot more time to run. As the GetConnections function is called in the PyNN function convergent_connect (in nest.projections) for connections with specific parameters other than delay and weight, this created a big slow down in our model during the building of the connections. That's why I modified this PyNN code to limit the call of the nest GetConnections function. We obtained a great speed up in our model during the building of connections (from 2 whole days to 45 minutes), and the new version of the code seems to pass all the PyNN tests. Hence I was thinking that sharing these modification could be maybe interesting for you.

In the code I wrote, the GetConnections function is called only if the common synapse properties have not been identified yet, otherwise all the connection parameters are set directly when calling the NEST Connect function, and not through the NEST SetStatus function. The exceptions to this are the parameter init_flag which produces a connection error (in the PyNN tests "test_create_with_homogeneous_common_properties" and "test_create_with_native_synapse") when passed in the GetConnections function as it apparently can't deal with boolean parameters, and the parameter "synapse_id" (in the two same PyNN tests, and in this case I can't really understand what's the problem) so the SetStatus function is used for these two parameters.