### PR TITLE
Fix problem due to changes in connection sorting in NEST (#672)

### DIFF
--- a/pyNN/nest/__init__.py
+++ b/pyNN/nest/__init__.py
@@ -103,7 +103,7 @@ def setup(timestep=DEFAULT_TIMESTEP, min_delay=DEFAULT_MIN_DELAY,
     `spike_precision`:
         should be "off_grid" (default) or "on_grid"
     `verbosity`:
-        INSERT DESCRIPTION OF POSSIBLE VALUES
+        one of: "all", "info", "deprecated", "warning", "error", "fatal"
     `recording_precision`:
         number of decimal places (OR SIGNIFICANT FIGURES?) in recorded data
     `threads`:

--- a/pyNN/nest/extensions/pynn_extensions.cpp
+++ b/pyNN/nest/extensions/pynn_extensions.cpp
@@ -24,6 +24,8 @@
 #include "kernel_manager.h"
 #include "model.h"
 #include "model_manager_impl.h"
+#include "nest.h"
+#include "nest_impl.h"
 #include "nestmodule.h"
 #include "target_identifier.h"
 
@@ -110,11 +112,7 @@ pynn::PyNNExtensions::init( SLIInterpreter* i )
      even further, but limits the number of available rports. Please see
      Kunkel et al, Front Neurofinfom 8:78 (2014), Sec 3.3.2, for details.
   */
-  nest::kernel()
-    .model_manager.register_connection_model< SimpleStochasticConnection< nest::
-        TargetIdentifierPtrRport > >( "simple_stochastic_synapse" );
-  nest::kernel()
-    .model_manager.register_connection_model< StochasticStpConnection< nest::
-        TargetIdentifierPtrRport > >( "stochastic_stp_synapse" );
+  nest::register_connection_model< SimpleStochasticConnection >( "simple_stochastic_synapse" );
+  nest::register_connection_model< StochasticStpConnection >( "stochastic_stp_synapse" );
 
 } // PyNNExtensions::init()

--- a/pyNN/nest/simulator.py
+++ b/pyNN/nest/simulator.py
@@ -64,6 +64,7 @@ class _State(common.control.BaseState):
         self.tempdirs = []
         self.recording_devices = []
         self.populations = []  # needed for reset
+        self.stale_connection_cache = False
 
     @property
     def t(self):

--- a/test/system/scenarios/test_connection_handling.py
+++ b/test/system/scenarios/test_connection_handling.py
@@ -45,6 +45,28 @@ def connection_access_weight_and_delay(sim):
                        target)
 connection_access_weight_and_delay.__test__ = False
 
+@register()
+def issue672(sim):
+    """
+    Check that creating new Projections does not mess up existing ones.
+    """
+    sim.setup(verbosity="error")
+
+    p1 = sim.Population(5, sim.IF_curr_exp())
+    p2 = sim.Population(4, sim.IF_curr_exp())
+    p3 = sim.Population(6, sim.IF_curr_exp())
+
+    prj1 = sim.Projection(p2, p3, sim.AllToAllConnector(), sim.StaticSynapse(weight=lambda d: d))
+    # Get weight array of first Projection
+    wA = prj1.get("weight", format="array")
+    # Create a new Projection
+    prj2 = sim.Projection(p2, p3, sim.AllToAllConnector(), sim.StaticSynapse(weight=lambda w: 1))
+    # Get weight array of first Projection again
+    #   - incorrect use of caching could lead to this giving different results
+    wB = prj1.get("weight", format="array")
+
+    assert_array_equal(wA, wB)
+
 
 if __name__ == '__main__':
     from pyNN.utility import get_simulator


### PR DESCRIPTION
We now invalidate the connection cache whenever connections are added to any Projection (cf #672)

The PR also includes a regression test. To avoid the constant warnings, this PR also changes the default verbosity level to "error", however if would be nice if we could turn off this warning specifically.