### PR TITLE
Support for NEST 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ matrix:
   include:
     - python: 3.6
       env: PYENV=py36
-    - python: 3.7
-      env: PYENV=py37
+    - python: 3.8
+      env: PYENV=py38
 before_install:
-  - sudo apt-get install -y libgsl0-dev  openmpi-bin libopenmpi-dev python-dev
+  - sudo apt-get install -y libgsl0-dev openmpi-bin libopenmpi-dev python-dev
 install:
   - source ci/install.sh
 script:  bash ci/test_script.sh
@@ -15,8 +15,8 @@ after_success:
   - bash ci/upload_coveralls.sh
 cache:
   directories:
-    - $HOME/nest-2.20.0
+    - $HOME/nest-3.0
     - $HOME/nrn-7.7
-    - $HOME/build/nest-2.20.0
+    - $HOME/build/nest-3.0
     - $HOME/build/nrn-7.7
     - $HOME/.cache/pip

--- a/ci/install_brian.sh
+++ b/ci/install_brian.sh
@@ -2,7 +2,7 @@
 
 set -e  # stop execution in case of errors
 
-if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
     echo -e "\n========== Installing Brian 2 ==========\n"
     pip install cython;
     pip install brian2;

--- a/ci/install_nest.sh
+++ b/ci/install_nest.sh
@@ -2,13 +2,13 @@
 
 set -e  # stop execution in case of errors
 
-if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
     echo -e "\n========== Installing NEST ==========\n"
     # Specify which version of NEST to install
     #export NEST_VERSION="master"
-    export NEST_VERSION="2.20.0"
+    export NEST_VERSION="3.0"
 
-    pip install cython  #==0.28.1
+    pip install cython
 
     if [ "$NEST_VERSION" = "master" ]; then
       export NEST="nest-simulator-$NEST_VERSION"
@@ -26,10 +26,9 @@ if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
     mkdir -p $HOME/build/$NEST
     pushd $HOME/build/$NEST
     export VENV=`python -c "import sys; print(sys.prefix)"`;
-    if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
-      ln -s /opt/python/3.7/lib/libpython3.7m.so $VENV/lib/libpython3.7.so;
-      export PYTHON_INCLUDE_DIR=$VENV/include/python${TRAVIS_PYTHON_VERSION}m
-    fi
+    export PYLIB=`find /opt/python/${TRAVIS_PYTHON_VERSION}/lib/ -name "libpython${TRAVIS_PYTHON_VERSION}*.so"`;
+    ln -s ${PYLIB} $VENV/lib/libpython${TRAVIS_PYTHON_VERSION}.so;
+    export PYTHON_INCLUDE_DIR=$VENV/include/python${TRAVIS_PYTHON_VERSION}m
     cython --version;
     cmake --version;
     cmake -DCMAKE_INSTALL_PREFIX=$VENV \

--- a/ci/install_nest.sh
+++ b/ci/install_nest.sh
@@ -26,8 +26,8 @@ if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
     mkdir -p $HOME/build/$NEST
     pushd $HOME/build/$NEST
     export VENV=`python -c "import sys; print(sys.prefix)"`;
-    export PYLIB=`find /opt/python/${TRAVIS_PYTHON_VERSION}/lib/ -name "libpython${TRAVIS_PYTHON_VERSION}*.so"`;
-    ln -s ${PYLIB} $VENV/lib/libpython${TRAVIS_PYTHON_VERSION}.so;
+    export PYLIB_GLOBAL=`find /opt/python/${TRAVIS_PYTHON_VERSION}/lib/ -name "libpython${TRAVIS_PYTHON_VERSION}*.so"`;
+    ln -s ${PYLIB_GLOBAL} $VENV/lib/libpython${TRAVIS_PYTHON_VERSION}.so;
     export PYTHON_INCLUDE_DIR=$VENV/include/python${TRAVIS_PYTHON_VERSION}m
     cython --version;
     cmake --version;

--- a/ci/install_neuron.sh
+++ b/ci/install_neuron.sh
@@ -2,7 +2,7 @@
 
 set -e  # stop execution in case of errors
 
-if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
     echo -e "\n========== Installing NEURON ==========\n"
     export NRN_VERSION="nrn-7.7"
     if [ ! -f "$HOME/$NRN_VERSION/configure" ]; then

--- a/ci/test_script.sh
+++ b/ci/test_script.sh
@@ -2,7 +2,7 @@
 
 set -e  # stop execution in case of errors
 
-if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
     python setup.py nosetests --with-coverage --cover-package=pyNN -v --tests=test;
 else
     python setup.py nosetests -e backends -v --tests=test/unittests;

--- a/ci/test_script.sh
+++ b/ci/test_script.sh
@@ -3,7 +3,7 @@
 set -e  # stop execution in case of errors
 
 if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
-    python setup.py nosetests --with-coverage --cover-package=pyNN -v --tests=test;
+    python setup.py nosetests --nologcapture --with-coverage --cover-package=pyNN -v --tests=test;
 else
-    python setup.py nosetests -e backends -v --tests=test/unittests;
+    python setup.py nosetests --nologcapture -e backends -v --tests=test/unittests;
 fi

--- a/ci/upload_coveralls.sh
+++ b/ci/upload_coveralls.sh
@@ -2,6 +2,6 @@
 
 set -e  # stop execution in case of errors
 
-if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+if [ "$TRAVIS_PYTHON_VERSION" == "3.8" ]; then
     coveralls;
 fi

--- a/pyNN/brian2/recording.py
+++ b/pyNN/brian2/recording.py
@@ -71,7 +71,7 @@ class Recorder(recording.Recorder):
         for device in self._devices.values():
             device.resize(0)
 
-    def _get_spiketimes(self, id):
+    def _get_spiketimes(self, id, clear=False):
         if is_listlike(id):
             all_spiketimes = {}
             for cell_id in id:

--- a/pyNN/common/populations.py
+++ b/pyNN/common/populations.py
@@ -843,10 +843,12 @@ class PopulationView(BasePopulation):
                 if len(self.mask) != len(self.parent):
                     raise Exception("Boolean masks should have the size of Parent Population")
                 self.mask = np.arange(len(self.parent))[self.mask]
-            if len(np.unique(self.mask)) != len(self.mask):
-                logging.warning(
-                    "PopulationView can contain only once each ID, duplicated IDs are removed")
-                self.mask = np.unique(self.mask)
+            else:
+                if len(np.unique(self.mask)) != len(self.mask):
+                    logging.warning(
+                        "PopulationView can contain only once each ID, duplicated IDs are removed")
+                    self.mask = np.unique(self.mask)
+                self.mask.sort()  # needed by NEST
         self.all_cells = self.parent.all_cells[self.mask]  # do we need to ensure this is ordered?
         idx = np.argsort(self.all_cells)
         self._is_sorted = np.all(idx == np.arange(len(self.all_cells)))

--- a/pyNN/common/populations.py
+++ b/pyNN/common/populations.py
@@ -848,8 +848,8 @@ class PopulationView(BasePopulation):
                     logging.warning(
                         "PopulationView can contain only once each ID, duplicated IDs are removed")
                     self.mask = np.unique(self.mask)
-                self.mask.sort()  # needed by NEST
-        self.all_cells = self.parent.all_cells[self.mask]  # do we need to ensure this is ordered?
+                self.mask.sort()  # needed by NEST. Maybe emit a warning or exception if mask is not already ordered?
+        self.all_cells = self.parent.all_cells[self.mask]
         idx = np.argsort(self.all_cells)
         self._is_sorted = np.all(idx == np.arange(len(self.all_cells)))
         self.size = len(self.all_cells)

--- a/pyNN/common/populations.py
+++ b/pyNN/common/populations.py
@@ -1205,7 +1205,7 @@ class Assembly(object):
         for p in self.populations:
             count += p.size
             boundaries.append(count)
-        boundaries = np.array(boundaries, dtype=np.int)
+        boundaries = np.array(boundaries, dtype=int)
 
         if isinstance(index, (int, np.integer)):  # return an ID
             pindex = boundaries[1:].searchsorted(index, side='right')

--- a/pyNN/connectors.py
+++ b/pyNN/connectors.py
@@ -550,7 +550,7 @@ class FromListConnector(Connector):
         #  - order of sorting/filtering by local
         #  - use np.unique, or just do in1d(self.conn_list)?
         idx = np.argsort(self.conn_list[:, 1])
-        targets = np.unique(self.conn_list[:, 1]).astype(np.int)
+        targets = np.unique(self.conn_list[:, 1]).astype(int)
         local = np.in1d(targets,
                            np.arange(projection.post.size)[projection.post._mask_local],
                            assume_unique=True)
@@ -566,7 +566,7 @@ class FromListConnector(Connector):
         logger.debug("right = %s", right)
 
         for tgt, l, r in zip(local_targets, left, right):
-            sources = self.conn_list[l:r, 0].astype(np.int)
+            sources = self.conn_list[l:r, 0].astype(int)
             connection_parameters = deepcopy(projection.synapse_type.parameter_space)
 
             connection_parameters.shape = (r - l,)

--- a/pyNN/mock/populations.py
+++ b/pyNN/mock/populations.py
@@ -1,5 +1,5 @@
 import numpy as np
-from pyNN import common
+from pyNN import common, errors
 from pyNN.standardmodels import StandardCellType
 from pyNN.parameters import ParameterSpace, simplify
 from . import simulator
@@ -29,7 +29,10 @@ class PopulationView(common.PopulationView):
     def _set_parameters(self, parameter_space):
         """parameter_space should contain native parameters"""
         for name, value in parameter_space.items():
-            self.parent._parameters[name][self.mask] = value.evaluate(simplify=True)
+            try:
+                self.parent._parameters[name][self.mask] = value.evaluate(simplify=True)
+            except ValueError as err:
+                raise errors.InvalidParameterValueError(f"{name} should not be of type {type(value)}")
 
     def _set_initial_value_array(self, variable, initial_values):
         pass

--- a/pyNN/mock/recording.py
+++ b/pyNN/mock/recording.py
@@ -9,7 +9,7 @@ class Recorder(recording.Recorder):
     def _record(self, variable, new_ids, sampling_interval=None):
         pass
 
-    def _get_spiketimes(self, id):
+    def _get_spiketimes(self, id, clear=False):
         if hasattr(id, "__len__"):
             spks = {}
             for i in id:

--- a/pyNN/nest/__init__.py
+++ b/pyNN/nest/__init__.py
@@ -104,6 +104,9 @@ def setup(timestep=DEFAULT_TIMESTEP, min_delay=DEFAULT_MIN_DELAY,
         a list of seeds, one for each thread on each MPI process
     `rng_seeds_seed`:
         a single seed that will be used to generate random values for `rng_seeds`
+    `t_flush`:
+        extra time to run the simulation after using reset() to ensure
+        the previous run does not influence the new one (default 200 ms)
     """
     max_delay = extra_params.get('max_delay', DEFAULT_MAX_DELAY)
     common.setup(timestep, min_delay, **extra_params)
@@ -124,6 +127,9 @@ def setup(timestep=DEFAULT_TIMESTEP, min_delay=DEFAULT_MIN_DELAY,
         simulator.state.rng_seed = extra_params['rng_seeds_seed']
     else:
         simulator.state.rng_seed = extra_params.get('rng_seed', 42)
+    if "t_flush" in extra_params:
+        # see https://github.com/nest/nest-simulator/issues/1618
+        simulator.state.t_flush = extra_params["t_flush"]
     # set resolution
     simulator.state.dt = timestep
     # Set min_delay and max_delay

--- a/pyNN/nest/__init__.py
+++ b/pyNN/nest/__init__.py
@@ -106,7 +106,7 @@ def setup(timestep=DEFAULT_TIMESTEP, min_delay=DEFAULT_MIN_DELAY,
         a single seed that will be used to generate random values for `rng_seeds`
     `t_flush`:
         extra time to run the simulation after using reset() to ensure
-        the previous run does not influence the new one (default 200 ms)
+        the previous run does not influence the new one
     """
     max_delay = extra_params.get('max_delay', DEFAULT_MAX_DELAY)
     common.setup(timestep, min_delay, **extra_params)

--- a/pyNN/nest/__init__.py
+++ b/pyNN/nest/__init__.py
@@ -19,11 +19,6 @@ from . import simulator
 from pyNN import common, recording, errors, space, __doc__
 from pyNN.common.control import DEFAULT_MAX_DELAY, DEFAULT_TIMESTEP, DEFAULT_MIN_DELAY
 
-try:
-    nest.GetStatus([np.int32(0)])
-except nest.kernel.NESTError:
-    raise Exception("NEST built without NumPy support. Try rebuilding NEST after installing np.")
-
 # if recording.MPI and (nest.Rank() != recording.mpi_comm.rank):
 #    raise Exception("MPI not working properly. Please make sure you import pyNN.nest before pyNN.random.")
 
@@ -121,13 +116,16 @@ def setup(timestep=DEFAULT_TIMESTEP, min_delay=DEFAULT_MIN_DELAY,
     # set kernel RNG seeds
     simulator.state.num_threads = extra_params.get('threads') or 1
     if 'grng_seed' in extra_params:
-        simulator.state.grng_seed = extra_params['grng_seed']
+        warnings.warn("The setup argument 'grng_seed' is now 'rng_seed'")
+        simulator.state.rng_seed = extra_params['grng_seed']
     if 'rng_seeds' in extra_params:
-        simulator.state.rng_seeds = extra_params['rng_seeds']
+        warnings.warn("The setup argument 'rng_seeds' is no longer available. Taking the first value for the global seed.")
+        simulator.state.rng_seed = extra_params['rng_seeds'][0]
+    if 'rng_seeds_seed' in extra_params:
+        warnings.warn("The setup argument 'rng_seeds_seed' is now 'rng_seed'")
+        simulator.state.rng_seed = extra_params['rng_seeds_seed']
     else:
-        rng = NumpyRNG(extra_params.get('rng_seeds_seed', 42))
-        n = simulator.state.num_processes * simulator.state.threads
-        simulator.state.rng_seeds = rng.next(n, 'uniform_int', {'low': 0, 'high': 100000}).tolist()
+        simulator.state.rng_seed = extra_params.get('rng_seed', 42)
     # set resolution
     simulator.state.dt = timestep
     # Set min_delay and max_delay

--- a/pyNN/nest/cells.py
+++ b/pyNN/nest/cells.py
@@ -50,7 +50,10 @@ def get_receptor_types(model_name):
 
 
 def get_recordables(model_name):
-    return [sl.name for sl in nest.GetDefaults(model_name).get("recordables", [])]
+    try:
+        return [name for name in nest.GetDefaults(model_name, "recordables")]
+    except nest.lib.hl_api_exceptions.NESTError as err:
+        return []
 
 
 def native_cell_type(model_name):
@@ -61,7 +64,7 @@ def native_cell_type(model_name):
     default_parameters, default_initial_values = get_defaults(model_name)
     receptor_types = get_receptor_types(model_name)
     recordable = get_recordables(model_name) + ['spikes']
-    element_type = nest.GetDefaults(model_name, 'element_type').name
+    element_type = nest.GetDefaults(model_name, 'element_type')
     return type(model_name,
                 (NativeCellType,),
                 {'nest_model': model_name,

--- a/pyNN/nest/cells.py
+++ b/pyNN/nest/cells.py
@@ -52,7 +52,7 @@ def get_receptor_types(model_name):
 def get_recordables(model_name):
     try:
         return [name for name in nest.GetDefaults(model_name, "recordables")]
-    except nest.lib.hl_api_exceptions.NESTError as err:
+    except nest.NESTError as err:
         return []
 
 

--- a/pyNN/nest/electrodes.py
+++ b/pyNN/nest/electrodes.py
@@ -26,6 +26,7 @@ class NestCurrentSource(BaseCurrentSource):
 
         self.min_delay = state.min_delay
         self.timestep = state.dt  # NoisyCurrentSource has a parameter called "dt", so use "timestep" here
+        state.current_sources.append(self)
 
     def inject_into(self, cells):
         for id in cells:
@@ -36,6 +37,15 @@ class NestCurrentSource(BaseCurrentSource):
         else:
             self.cell_list = cells
         nest.Connect(self._device, self.cell_list, syn_spec={"delay": state.min_delay})
+
+    def _reset(self):
+        # after a reset, need to adjust parameters for time offset
+        updated_params = {}
+        for name, value in self.parameter_space.items():
+            if name in ("start", "stop", "amplitude_times"):
+                updated_params[name] = value
+        if updated_params:
+            state.set_status(self._device, updated_params)
 
     def _delay_correction(self, value):
         """
@@ -92,5 +102,5 @@ class NativeElectrodeType(NestCurrentSource):
     def __init__(self, **parameters):
         NestCurrentSource.__init__(self, **parameters)
         self.parameter_space.evaluate(simplify=True)
-        nest.SetStatus(self._device,
+        state.set_status(self._device,
                        make_sli_compatible(self.parameter_space.as_dict()))

--- a/pyNN/nest/populations.py
+++ b/pyNN/nest/populations.py
@@ -30,18 +30,20 @@ class PopulationMixin(object):
         parameter_space should contain native parameters
         """
         param_dict = _build_params(parameter_space, np.where(self._mask_local)[0])
-        ids = self.local_cells.tolist()
         if hasattr(self.celltype, "uses_parrot") and self.celltype.uses_parrot:
-            ids = [id.source for id in ids]
-        nest.SetStatus(ids, param_dict)
+            ids = self.node_collection_source[self._mask_local]
+        else:
+            ids = self.node_collection[self._mask_local]
+        simulator.state.set_status(ids, param_dict)
 
     def _get_parameters(self, *names):
         """
         return a ParameterSpace containing native parameters
         """
-        ids = self.local_cells.tolist()
         if hasattr(self.celltype, "uses_parrot") and self.celltype.uses_parrot:
-            ids = [id.source for id in ids]
+            ids = self.node_collection_source[self._mask_local]
+        else:
+            ids = self.node_collection[self._mask_local]
 
         if "spike_times" in names:
             parameter_dict = {"spike_times": [Sequence(value)
@@ -59,16 +61,35 @@ class PopulationMixin(object):
         ps = ParameterSpace(parameter_dict, shape=(self.local_size,))
         return ps
 
+    @property
+    def local_node_collection(self):
+        return self.node_collection[self._mask_local]
+
 
 class Assembly(common.Assembly):
     __doc__ = common.Assembly.__doc__
     _simulator = simulator
+
+    @property
+    def local_node_collection(self):
+        result = self.populations[0].local_node_collection
+        for p in self.populations[1:]:
+            result += p.local_node_collection
+        return result
 
 
 class PopulationView(common.PopulationView, PopulationMixin):
     __doc__ = common.PopulationView.__doc__
     _simulator = simulator
     _assembly_class = Assembly
+
+    @property
+    def node_collection(self):
+        return self.parent.node_collection[self.mask]
+
+    @property
+    def node_collection_source(self):
+        return self.parent.node_collection_source[self.mask]
 
 
 def _build_params(parameter_space, mask_local, size=None, extra_parameters=None):
@@ -134,7 +155,7 @@ class Population(common.Population, PopulationMixin):
                                    None,
                                    size=self.size)
         try:
-            self.all_cells = nest.Create(nest_model, self.size, params=params)
+            self.node_collection = nest.Create(nest_model, self.size, params=params)
         except nest.kernel.NESTError as err:
             if "UnknownModelName" in err.args[0] and "cond" in err.args[0]:
                 raise errors.InvalidModelError("%s Have you compiled NEST with the GSL (Gnu Scientific Library)?" % err)
@@ -143,25 +164,37 @@ class Population(common.Population, PopulationMixin):
             raise  # errors.InvalidModelError(err)
         # create parrot neurons if necessary
         if hasattr(self.celltype, "uses_parrot") and self.celltype.uses_parrot:
-            self.all_cells_source = np.array(self.all_cells)        # we put the parrots into all_cells, since this will
+            self.node_collection_source = self.node_collection          # we put the parrots into all_cells, since this will
             parrot_model = simulator.state.spike_precision == "off_grid" and "parrot_neuron_ps" or "parrot_neuron"
-            self.all_cells = nest.Create(parrot_model, self.size)      # be used for connections and recording. all_cells_source
-                                                                       # should be used for setting parameters
+            self.node_collection = nest.Create(parrot_model, self.size) # be used for connections and recording. all_cells_source
+                                                                        # should be used for setting parameters
             self._deferred_parrot_connections = True
             # connecting up the parrot neurons is deferred until we know the value of min_delay
             # which could be 'auto' at this point.
-        self._mask_local = np.array(nest.GetStatus(self.all_cells, 'local'))
-        self.all_cells = np.array([simulator.ID(gid) for gid in self.all_cells], simulator.ID)
+        if self.node_collection.local is True:
+            self._mask_local = np.array([True])
+        else:
+            self._mask_local = np.array(self.node_collection.local)
+        self.all_cells = np.array([simulator.ID(gid) for gid in self.node_collection.tolist()], simulator.ID)
         for gid in self.all_cells:
             gid.parent = self
+            gid.node_collection = nest.NodeCollection([int(gid)])
         if hasattr(self.celltype, "uses_parrot") and self.celltype.uses_parrot:
-            for gid, source in zip(self.all_cells, self.all_cells_source):
+            for gid, source in zip(self.all_cells, self.node_collection_source.tolist()):
                 gid.source = source
 
     def _connect_parrot_neurons(self):
-        nest.Connect(self.all_cells_source, np.array(self.all_cells, int), 'one_to_one',
+        nest.Connect(self.node_collection_source, self.node_collection, 'one_to_one',
                      syn_spec={'delay': simulator.state.min_delay})
         self._deferred_parrot_connections = False
+
+    def _reset(self):
+        # adjust parameters that represent absolute times for the time offset after reset
+        if hasattr(self.celltype, "uses_parrot") and self.celltype.uses_parrot:
+            for name in self.celltype.get_native_names():
+                if name in ("start", "stop", "spike_times"):
+                    value = self.celltype.native_parameters[name]
+                    self._simulator.set_status(self.node_collection, name, value)
 
     def _set_initial_value_array(self, variable, value):
         variable = VARIABLE_MAP.get(variable, variable)
@@ -170,7 +203,10 @@ class Population(common.Population, PopulationMixin):
         else:
             local_values = value._partially_evaluate(self._mask_local, simplify=True)
         try:
-            nest.SetStatus(self.local_cells.tolist(), variable, local_values)
+            if self._mask_local.dtype == bool and self._mask_local.size == 1 and self._mask_local[0]:
+                simulator.state.set_status(self.node_collection, variable, local_values)
+            else:
+                simulator.state.set_status(self.node_collection[self._mask_local], variable, local_values)
         except nest.kernel.NESTError as e:
             if "Unused dictionary items" in e.args[0]:
                 logger.warning("NEST does not allow setting an initial value for %s" % variable)

--- a/pyNN/nest/populations.py
+++ b/pyNN/nest/populations.py
@@ -77,6 +77,11 @@ class Assembly(common.Assembly):
             result += p.local_node_collection
         return result
 
+    @property
+    def node_collection(self):
+        return sum((p.node_collection for p in self.populations[1:]),
+                   start=self.populations[0].node_collection)
+
 
 class PopulationView(common.PopulationView, PopulationMixin):
     __doc__ = common.PopulationView.__doc__
@@ -214,3 +219,6 @@ class Population(common.Population, PopulationMixin):
                 # and raise an Exception if not, rather than just emit a warning.
             else:
                 raise
+
+
+

--- a/pyNN/nest/projections.py
+++ b/pyNN/nest/projections.py
@@ -7,6 +7,8 @@ NEST v2 implementation of the PyNN API.
 
 """
 
+from collections import defaultdict
+from pyNN.utility import connection_plot
 import numpy as np
 import nest
 import logging
@@ -31,6 +33,28 @@ def listify(obj):
         return obj
 
 
+def split_array_to_avoid_repeats(arr, **associated_arrays):
+    assert arr.dtype == int
+    n_sub_arrays = np.bincount(arr).max()
+    split_indices = [[] for i in range(n_sub_arrays)]
+    index_pointer = defaultdict(int)
+    for i, element in enumerate(arr):
+        split_index = index_pointer[element]
+        split_indices[split_index].append(i)
+        index_pointer[element] += 1
+    sub_arrays = [arr[split_index] for split_index in split_indices]
+    sub_associated = []
+    for split_index in split_indices:
+        assoc = {}
+        for key, value in associated_arrays.items():
+            if isinstance(value, np.ndarray):
+                assoc[key] = value[split_index]
+            else:
+                assoc[key] = value
+        sub_associated.append(assoc)
+    return sub_arrays, sub_associated
+
+
 class Projection(common.Projection):
     __doc__ = common.Projection.__doc__
     _simulator = simulator
@@ -44,8 +68,8 @@ class Projection(common.Projection):
                                    space, label)
         self.nest_synapse_model = self.synapse_type._get_nest_synapse_model()
         self.nest_synapse_label = Projection._nProj
-        self.synapse_type._set_tau_minus(self.post.local_cells)
-        self._sources = []
+        self.synapse_type._set_tau_minus(self.post.local_node_collection)
+        self._sources = set()
         self._connections = None
         # This is used to keep track of common synapse properties
         self._common_synapse_properties = {}
@@ -78,11 +102,11 @@ class Projection(common.Projection):
     @property
     def nest_connections(self):
         if self._connections is None or self._simulator.state.stale_connection_cache:
-            self._sources = np.unique(self._sources)
-            if self._sources.size > 0:
-                self._connections = nest.GetConnections(self._sources.tolist(),
-                                                        synapse_model=self.nest_synapse_model,
-                                                        synapse_label=self.nest_synapse_label)
+            if len(self._sources) > 0:
+                self._connections = nest.GetConnections(
+                    nest.NodeCollection(sorted(self._sources)),
+                    synapse_model=self.nest_synapse_model,
+                    synapse_label=self.nest_synapse_label)
             else:
                 self._connections = []
             self._simulator.state.stale_connection_cache = False
@@ -123,9 +147,10 @@ class Projection(common.Projection):
         Use the connection between the sample indices to distinguish
         between local and common synapse properties.
         """
-        sample_connection = nest.GetConnections(source=[int(self._sources[0])],
-                                                synapse_model=self.nest_synapse_model,
-                                                synapse_label=self.nest_synapse_label)[:1]
+        sample_connection = nest.GetConnections(
+            source=nest.NodeCollection([next(iter(self._sources))]),  # take any source from the set
+            synapse_model=self.nest_synapse_model,
+            synapse_label=self.nest_synapse_label)[:1]
 
         local_parameters = nest.GetStatus(sample_connection)[0].keys()
         all_parameters = nest.GetDefaults(self.nest_synapse_model).keys()
@@ -160,21 +185,19 @@ class Projection(common.Projection):
         `postsynaptic_index` - integer - the index of the postsynaptic neuron
         `connection_parameters` - dict whose keys are native NEST parameter names. Values may be scalars or arrays.
         """
-        #logger.debug("Connecting to index %s from %s with %s" % (postsynaptic_index, presynaptic_indices, connection_parameters))
-
-        presynaptic_cells = self.pre.all_cells[presynaptic_indices].astype(int).tolist()
-        postsynaptic_cell = self.post[postsynaptic_index]
-        postsynaptic_cell_id = [int(postsynaptic_cell)]
-        assert len(presynaptic_cells) > 0, presynaptic_cells
-        self._sources.extend(presynaptic_cells)
+        # Clean the connection parameters by removing parameters that are
+        # used by PyNN but should not be passed to NEST
+        connection_parameters.pop('tau_minus', None)  # TODO: set tau_minus on the post-synaptic cells
+        connection_parameters.pop('dendritic_delay_fraction', None)
+        connection_parameters.pop('w_min_always_zero_in_NEST', None)
 
         syn_dict = {
-            'model': self.nest_synapse_model,
+            'synapse_model': self.nest_synapse_model,
             'synapse_label': self.nest_synapse_label,
         }
 
         # Weights require some special handling
-        weights = connection_parameters.pop('weight')
+        weights = connection_parameters['weight']
         if self.receptor_type == 'inhibitory' and self.post.conductance_based:
             weights *= -1  # NEST wants negative values for inhibitory weights, even if these are conductances
             if "stdp" in self.nest_synapse_model:
@@ -186,90 +209,108 @@ class Projection(common.Projection):
         if hasattr(self.post, "celltype") and hasattr(self.post.celltype, "receptor_scale"):  # this is a bit of a hack
             weights *= self.post.celltype.receptor_scale                                      # needed for the Izhikevich model
 
-        delays = connection_parameters.pop('delay')
-
-        # Clean the connection parameters by removing parameters that are
-        # used by PyNN but should not be passed to NEST
-        connection_parameters.pop('tau_minus', None)  # TODO: set tau_minus on the post-synaptic cells
-        connection_parameters.pop('dendritic_delay_fraction', None)
-        connection_parameters.pop('w_min_always_zero_in_NEST', None)
+        # Prepare connections. NodeCollections can't have repeated values, so for some
+        # connector types we need to split the presynaptic cells into groups that
+        # don't have such repeats.
+        presynaptic_indices.sort()
+        try:
+            presynaptic_cell_groups = [self.pre.node_collection[presynaptic_indices]]
+            connection_parameter_groups =  [connection_parameters]
+        except ValueError as err:
+            if "All node IDs in a NodeCollection have to be unique" in str(err):
+                if any(hasattr(val, "__len__") for val in connection_parameters.values()):
+                    raise NotImplementedError("Needs re-implementing for NEST v3")
+                presynaptic_index_groups, connection_parameter_groups = \
+                    split_array_to_avoid_repeats(presynaptic_indices, **connection_parameters)
+                presynaptic_cell_groups = [self.pre.node_collection[i] for i in presynaptic_index_groups]
+            else:
+                raise
+        postsynaptic_cell = self.post[postsynaptic_index]
 
         # Create connections and set parameters
-        try:
-            # nest.Connect expects a 2D array
-            if not np.isscalar(weights):
-                weights = np.array([weights])
-            if not np.isscalar(delays):
-                delays = np.array([delays])
-            syn_dict.update({'weight': weights, 'delay': delays})
+        for presynaptic_cells, connection_parameter_group in zip(presynaptic_cell_groups,
+                                                                 connection_parameter_groups):
+            try:
+                weights = connection_parameter_group.pop('weight')
+                delays = connection_parameter_group.pop('delays')
+                # nest.Connect expects a 2D array
+                if not np.isscalar(weights):
+                    weights = np.array([weights])
+                if not np.isscalar(delays):
+                    delays = np.array([delays])
+                syn_dict.update({'weight': weights, 'delay': delays})
 
-            if postsynaptic_cell.celltype.standard_receptor_type:
-                # For Tsodyks-Markram synapses models we set the "tau_psc" parameter to match
-                # the relevant "tau_syn" parameter from the post-synaptic neuron.
-                if 'tsodyks' in self.nest_synapse_model:
-                    if self.receptor_type == 'inhibitory':
-                        param_name = postsynaptic_cell.celltype.translations['tau_syn_I']['translated_name']
-                    elif self.receptor_type == 'excitatory':
-                        param_name = postsynaptic_cell.celltype.translations['tau_syn_E']['translated_name']
-                    else:
-                        raise NotImplementedError()
-                    syn_dict["tau_psc"] = nest.GetStatus(postsynaptic_cell_id, param_name)[0]
-            else:
-                syn_dict.update(
-                    {"receptor_type": postsynaptic_cell.celltype.get_receptor_type(
-                        self.receptor_type)})
-
-            # For parameters other than weight and delay, we need to know if they are "common"
-            # parameters (the same for all synapses) or "local" (different synapses can have
-            # different values), as this affects how they are set.
-            #
-            # To introspect which parameters are common, we need an existing connection, so
-            # the first time we create connections we pass just the weight and delay, and set
-            # the other parameters later. We then get the list of common parameters and cache
-            # it so that in subsequent Connect() calls we can pass all of the local
-            # (non-common) parameters.
-            if self._common_synapse_property_names is None:
-                nest.Connect(presynaptic_cells,
-                             postsynaptic_cell_id,
-                             'all_to_all',
-                             syn_dict)
-                self._identify_common_synapse_properties()
-
-                # Retrieve connections so that we can set additional
-                # parameters using nest.SetStatus
-                connections = nest.GetConnections(source=presynaptic_cells,
-                                                  target=postsynaptic_cell_id,
-                                                  synapse_model=self.nest_synapse_model,
-                                                  synapse_label=self.nest_synapse_label)
-                # not sure why we need to sort here
-                sort_indices = np.argsort(presynaptic_cells)
-                for name, value in connection_parameters.items():
-                    if name not in self._common_synapse_property_names:
-                        value = make_sli_compatible(value)
-                        if isinstance(value, np.ndarray):
-                            nest.SetStatus(connections, name, value[sort_indices].tolist())
+                if postsynaptic_cell.celltype.standard_receptor_type:
+                    # For Tsodyks-Markram synapses models we set the "tau_psc" parameter to match
+                    # the relevant "tau_syn" parameter from the post-synaptic neuron.
+                    if 'tsodyks' in self.nest_synapse_model:
+                        if self.receptor_type == 'inhibitory':
+                            param_name = postsynaptic_cell.celltype.translations['tau_syn_I']['translated_name']
+                        elif self.receptor_type == 'excitatory':
+                            param_name = postsynaptic_cell.celltype.translations['tau_syn_E']['translated_name']
                         else:
-                            nest.SetStatus(connections, name, value)
-                    else:
-                        self._set_common_synapse_property(name, value)
-            else:
-                # Since we know which parameters are common, we can set the non-common
-                # parameters directly in the nest.Connect call
-                syn_dict = self._update_syn_params(syn_dict, connection_parameters)
-                nest.Connect(presynaptic_cells,
-                             postsynaptic_cell_id,
-                             'all_to_all',
-                             syn_dict)
-                # and then set the common parameters
-                for name, value in connection_parameters.items():
-                    if name in self._common_synapse_property_names:
-                        self._set_common_synapse_property(name, value)
+                            raise NotImplementedError()
+                        syn_dict["tau_psc"] = nest.GetStatus(postsynaptic_cell.node_collection,
+                                                             param_name)[0]
+                else:
+                    syn_dict.update(
+                        {"receptor_type": postsynaptic_cell.celltype.get_receptor_type(
+                            self.receptor_type)})
 
-        except nest.kernel.NESTError as e:
-            errmsg = "%s. presynaptic_cells=%s, postsynaptic_cell=%s, weights=%s, delays=%s, synapse model='%s'" % (
-                e, presynaptic_cells, postsynaptic_cell,
-                weights, delays, self.nest_synapse_model)
-            raise errors.ConnectionError(errmsg)
+                # For parameters other than weight and delay, we need to know if they are "common"
+                # parameters (the same for all synapses) or "local" (different synapses can have
+                # different values), as this affects how they are set.
+                #
+                # To introspect which parameters are common, we need an existing connection, so
+                # the first time we create connections we pass just the weight and delay, and set
+                # the other parameters later. We then get the list of common parameters and cache
+                # it so that in subsequent Connect() calls we can pass all of the local
+                # (non-common) parameters.
+
+                for presynaptic_cells in presynaptic_cell_groups:
+                    if self._common_synapse_property_names is None:
+                        nest.Connect(presynaptic_cells,
+                                     postsynaptic_cell.node_collection,
+                                     'all_to_all',
+                                     syn_dict)
+                        self._identify_common_synapse_properties()
+
+                        # Retrieve connections so that we can set additional
+                        # parameters using nest.SetStatus
+                        connections = nest.GetConnections(source=presynaptic_cells,
+                                                          target=postsynaptic_cell,
+                                                          synapse_model=self.nest_synapse_model,
+                                                          synapse_label=self.nest_synapse_label)
+                        # not sure why we need to sort here
+                        sort_indices = np.argsort(presynaptic_cells)
+                        for name, value in connection_parameter_group.items():
+                            if name not in self._common_synapse_property_names:
+                                value = make_sli_compatible(value)
+                                if isinstance(value, np.ndarray):
+                                    nest.SetStatus(connections, name, value[sort_indices].tolist())
+                                else:
+                                    nest.SetStatus(connections, name, value)
+                            else:
+                                self._set_common_synapse_property(name, value)
+                    else:
+                        # Since we know which parameters are common, we can set the non-common
+                        # parameters directly in the nest.Connect call
+                        syn_dict = self._update_syn_params(syn_dict, connection_parameter_group)
+                        nest.Connect(presynaptic_cells,
+                                     postsynaptic_cell,
+                                     'all_to_all',
+                                     syn_dict)
+                        # and then set the common parameters
+                        for name, value in connection_parameter_group.items():
+                            if name in self._common_synapse_property_names:
+                                self._set_common_synapse_property(name, value)
+                    self._sources.update(presynaptic_cells.tolist())
+
+            except nest.kernel.NESTError as e:
+                errmsg = "%s. presynaptic_cells=%s, postsynaptic_cell=%s, weights=%s, delays=%s, synapse model='%s'" % (
+                    e, presynaptic_cells, postsynaptic_cell,
+                    weights, delays, self.nest_synapse_model)
+                raise errors.ConnectionError(errmsg)
 
         # Reset the caching of the connection list, since this will have to be recalculated
         self._connections = None
@@ -281,17 +322,17 @@ class Projection(common.Projection):
                              "within a single Projection with NEST.")
         # only columns for connections that exist on this machine
         parameter_space.evaluate(mask=(slice(None), self.post._mask_local))
-        sources = np.unique(self._sources).tolist()
+        sources = nest.NodeCollection(sorted(self._sources))
         if self._common_synapse_property_names is None:
             self._identify_common_synapse_properties()
         for postsynaptic_cell, connection_parameters in zip(self.post.local_cells,
                                                             parameter_space.columns()):
             connections = nest.GetConnections(source=sources,
-                                              target=[postsynaptic_cell],
+                                              target=postsynaptic_cell.node_collection,
                                               synapse_model=self.nest_synapse_model,
                                               synapse_label=self.nest_synapse_label)
             if connections:
-                source_mask = self.pre.id_to_index([x[0] for x in connections])
+                source_mask = self.pre.id_to_index(list(connections.sources()))
                 for name, value in connection_parameters.items():
                     if name == "weight" and self.receptor_type == 'inhibitory' and self.post.conductance_based:
                         value *= -1  # NEST uses negative values for inhibitory weights, even if these are conductances

--- a/pyNN/nest/recording.py
+++ b/pyNN/nest/recording.py
@@ -33,7 +33,6 @@ class RecordingDevice(object):
 
     def __init__(self, device_parameters, to_memory=True):
         # to be called at the end of the subclass __init__
-        device_parameters.update(withgid=True, withtime=True)
         if to_memory:
             self.device.record_to = "memory"
         else:

--- a/pyNN/nest/recording.py
+++ b/pyNN/nest/recording.py
@@ -39,6 +39,7 @@ class RecordingDevice(object):
             self.device.record_to = "ascii"
         self._all_ids = set([])
         self._connected = False
+        self._overrun_data = None
         simulator.state.recording_devices.append(self)
         _set_status(self.device, device_parameters)
 
@@ -55,10 +56,26 @@ class RecordingDevice(object):
         nest_variable = VARIABLE_MAP.get(variable, variable)
         events = nest.GetStatus(self.device, 'events')[0]
         ids = events['senders']
-        # I'm hoping numpy optimises for the case where scale_factor = 1, otherwise should avoid this multiplication in that case
-        values = events[nest_variable] * scale_factor
+        times = events["times"] - simulator.state._time_offset
         if variable == "times":
-            values -= simulator.state._time_offset
+            values = times
+        else:
+            # I'm hoping numpy optimises for the case where scale_factor = 1, otherwise should avoid this multiplication in that case
+            values = events[nest_variable] * scale_factor
+
+        if clear:
+            future_times_index = times > simulator.state.t
+            if future_times_index.any():
+                new_overrun_data = {
+                    "ids": ids[future_times_index],
+                    "values": values[future_times_index]
+                }
+            else:
+                new_overrun_data = None
+            if self._overrun_data:
+                ids = np.hstack((self._overrun_data["ids"], ids))
+                values = np.hstack((self._overrun_data["values"], values))
+            self._overrun_data = new_overrun_data
 
         data = {}
         recorded_ids = set(ids)
@@ -74,26 +91,24 @@ class RecordingDevice(object):
         data = {k: data[k] for k in desired_and_existing_ids}
 
         if variable != 'times':
+            if variable not in self._initial_values:
+                self._initial_values[variable] = {}
             for id in desired_ids:
                 # NEST does not record values at the zeroth time step, so we
                 # add them here.
-                if variable not in self._initial_values:
-                    self._initial_values[variable] = {}
                 initial_value = self._initial_values[variable].get(int(id),
                                                                    id.get_initial_value(variable))
-
                 if simulator.state.segment_counter == 0:
                     data[int(id)] = [initial_value] + data.get(int(id), [])
                 else:
                     if len(data[int(id)]) > 0:
                         data[int(id)][0] = initial_value
 
-                # if `get_data()` is called in the middle of a simulation, the
+                # if `get_data(..., clear=True)` is called in the middle of a simulation, the
                 # value at the last time point will become the initial value for
                 # the next time `get_data()` is called
                 if clear:
                     self._initial_values[variable][int(id)] = data[int(id)][-1]
-
         return data
 
 
@@ -118,14 +133,14 @@ class SpikeDetector(RecordingDevice):
                          {'delay': simulator.state.min_delay})
         self._connected = True
 
-    def get_spiketimes(self, desired_ids):
+    def get_spiketimes(self, desired_ids, clear=False):
         """
         Return spike times as a dictionary containing one numpy array for
         each neuron, ids as keys.
 
         Equivalent to `get_data('times', desired_ids)`
         """
-        return self.get_data('times', desired_ids)
+        return self.get_data('times', desired_ids, clear=clear)
 
     def get_spike_counts(self, desired_ids):
         events = nest.GetStatus(self.device, 'events')[0]
@@ -166,224 +181,6 @@ class Multimeter(RecordingDevice):
         _set_status(self.device, {'record_from': list(current_variables)})
 
 
-# class RecordingDevice(object):
-#    scale_factors = {'V_m': 1, 'g_ex': 0.001, 'g_in': 0.001}
-#
-#    def __init__(self, device_type, to_memory=False):
-#        assert device_type in ("multimeter", "spike_detector")
-#        self.type      = device_type
-#        self.device    = nest.Create(device_type)
-#        self.to_memory = to_memory
-#        device_parameters = {"withgid": True, "withtime": True}
-#        if self.type is 'multimeter':
-#            device_parameters["interval"] = simulator.state.dt
-#        else:
-#            device_parameters["precise_times"] = True
-#            device_parameters["precision"] = simulator.state.default_recording_precision
-#        if to_memory:
-#            device_parameters.update(to_file=False, to_memory=True)
-#        else:
-#            device_parameters.update(to_file=True, to_memory=False)
-#        try:
-#            nest.SetStatus(self.device, device_parameters)
-#        except nest.kernel.NESTError as e:
-#            raise nest.kernel.NESTError("%s. Parameter dictionary was: %s" % (e, device_parameters))
-#
-#        self.record_from = []
-#        self._local_files_merged = False
-#        self._gathered = False
-#        self._connected = False
-#        self._all_ids = set([])
-#        simulator.state.recording_devices.append(self)
-#        logger.debug("Created %s with parameters %s" % (device_type, device_parameters))
-#
-#    def __del__(self):
-#        for name in "_merged_file", "_gathered_file":
-#            if hasattr(self, name):
-#                getattr(self, name).close()
-#
-#    def add_variables(self, *variables):
-#        assert self.type is "multimeter", "Can't add variables to a spike detector"
-#        self.record_from.extend(variables)
-#        nest.SetStatus(self.device, {'record_from': self.record_from})
-#
-#    def add_cells(self, new_ids):
-#        self._all_ids = self._all_ids.union(new_ids)
-#
-#    def connect_to_cells(self):
-#        if not self._connected:
-#            ids = list(self._all_ids)
-#            if self.type is "spike_detector":
-#                nest.ConvergentConnect(ids, self.device, model='static_synapse')
-#            else:
-#                nest.DivergentConnect(self.device, ids, model='static_synapse')
-#            self._connected = True
-#
-#    def in_memory(self):
-#        """Determine whether data is being recorded to memory."""
-#        return nest.GetStatus(self.device, 'to_memory')[0]
-#
-#    def events_to_array(self, events):
-#        """
-#        Transform the NEST events dictionary (when recording to memory) to a
-#        Numpy array.
-#        """
-#        ids = events['senders']
-#        times = events['times']
-#        if self.type == 'spike_detector':
-#            data = np.array((ids, times)).T
-#        else:
-#            data = [ids, times]
-#            for var in self.record_from:
-#                data.append(events[var])
-#            data = np.array(data).T
-#        return data
-#
-#    def scale_data(self, data):
-#        """
-#        Scale the data to give appropriate units.
-#        """
-#        scale_factors = [RecordingDevice.scale_factors.get(var, 1)
-#                         for var in self.record_from]
-#        for i, scale_factor in enumerate(scale_factors):
-#            column = i+2 # first two columns are id and t, which should not be scaled.
-#            if scale_factor != 1:
-#                data[:, column] *= scale_factor
-#        return data
-#
-#    def add_initial_values(self, data):
-#        """
-#        Add initial values (NEST does not record the value at t=0).
-#        """
-#        logger.debug("Prepending initial values to recorded data")
-#        initial_values = []
-#        for id in self._all_ids:
-#            initial = [id, 0.0]
-#            for variable in self.record_from:
-#                variable = REVERSE_VARIABLE_MAP.get(variable, variable)
-#                try:
-#                    initial.append(id.get_initial_value(variable))
-#                except KeyError:
-#                    initial.append(0.0) # unsatisfactory
-#            initial_values.append(initial)
-#        if initial_values:
-#            data = np.concatenate((initial_values, data))
-#        return data
-#
-#    def read_data_from_memory(self, gather, compatible_output):
-#        """
-#        Return memory-recorded data.
-#
-#        `gather` -- if True, gather data from all MPI nodes.
-#        `compatible_output` -- if True, transform the data into the PyNN
-#                               standard format.
-#        """
-#        data = nest.GetStatus(self.device,'events')[0]
-#        if compatible_output:
-#            data = self.events_to_array(data)
-#            data = self.scale_data(data)
-#        if gather and simulator.state.num_processes > 1:
-#            data = recording.gather(data)
-#            self._gathered_file = tempfile.TemporaryFile()
-#            np.save(self._gathered_file, data)
-#            self._gathered = True
-#        return data
-#
-#    def read_local_data(self, compatible_output):
-#        """
-#        Return file-recorded data from the local MPI node, merging data from
-#        different threads if applicable.
-#
-#        The merged data is cached, to avoid the overhead of re-merging if the
-#        method is called again.
-#        """
-#        # what if the method is called with different values of
-#        # `compatible_output`? Need to cache these separately.
-#        if self._local_files_merged:
-#            logger.debug("Loading merged data from cache")
-#            self._merged_file.seek(0)
-#            data = np.load(self._merged_file)
-#        else:
-#            d = nest.GetStatus(self.device)[0]
-#            if "filenames" in d:
-#                nest_files = d['filenames']
-#            else: # indicates that run() has not been called.
-#                raise errors.NothingToWriteError("No recorder data. Have you called run()?")
-#            # possibly we can just keep on saving to the end of self._merged_file, instead of concatenating everything in memory
-#            logger.debug("Concatenating data from the following files: %s" % ", ".join(nest_files))
-#            non_empty_nest_files = [filename for filename in nest_files if os.stat(filename).st_size > 0]
-#            if len(non_empty_nest_files) > 0:
-#                data_list = [np.loadtxt(nest_file) for nest_file in non_empty_nest_files]
-#                data_list = [np.atleast_2d(np.loadtxt(nest_file))
-#                             for nest_file in non_empty_nest_files]
-#                data = np.concatenate(data_list)
-#            if len(non_empty_nest_files) == 0 or data.size == 0:
-#                if self.type is "spike_detector":
-#                    ncol = 2
-#                else:
-#                    ncol = 2 + len(self.record_from)
-#                data = np.empty([0, ncol])
-#            if compatible_output and self.type is not "spike_detector":
-#                data = self.scale_data(data)
-#                data = self.add_initial_values(data)
-#            self._merged_file = tempfile.TemporaryFile()
-#            np.save(self._merged_file, data)
-#            self._local_files_merged = True  # this is set back to False by run()
-#        return data
-#
-#    def read_data(self, gather, compatible_output, always_local=False):
-#        """
-#        Return file-recorded data.
-#
-#        `gather` -- if True, gather data from all MPI nodes.
-#        `compatible_output` -- if True, transform the data into the PyNN
-#                               standard format.
-#
-#        Gathered data is cached, so the MPI communication need only be done
-#        once, even if the method is called multiple times.
-#        """
-#        # what if the method is called with different values of
-#        # `compatible_output`? Need to cache these separately.
-#        if not self.to_memory:
-#            if gather and simulator.state.num_processes > 1:
-#                if self._gathered:
-#                    logger.debug("Loading previously gathered data from cache")
-#                    self._gathered_file.seek(0)
-#                    data = np.load(self._gathered_file)
-#                else:
-#                    local_data = self.read_local_data(compatible_output)
-#                    if always_local:
-#                        data = local_data # for always_local cells, no need to gather
-#                    else:
-#                        logger.debug("Gathering data")
-#                        data = recording.gather(local_data)
-#                    logger.debug("Caching gathered data")
-#                    self._gathered_file = tempfile.TemporaryFile()
-#                    np.save(self._gathered_file, data)
-#                    self._gathered = True
-#            else:
-#                data = self.read_local_data(compatible_output)
-#            if len(data.shape) == 1:
-#                data = data.reshape((1, data.size))
-#            return data
-#        else:
-#            return self.read_data_from_memory(gather, compatible_output)
-#
-#    def read_subset(self, variables, gather, compatible_output, always_local=False):
-#        if self.in_memory():
-#            data = self.read_data_from_memory(gather, compatible_output)
-#        else: # in file
-#            data = self.read_data(gather, compatible_output, always_local)
-#        indices = []
-#        for variable in variables:
-#            try:
-#                indices.append(self.record_from.index(variable))
-#            except ValueError:
-#                raise Exception("%s not recorded" % variable)
-#        columns = tuple([0, 1] + [index + 2 for index in indices])
-#        return data[:, columns]
-
-
 class Recorder(recording.Recorder):
     """Encapsulates data and functions related to recording model variables."""
     _simulator = simulator
@@ -397,21 +194,6 @@ class Recorder(recording.Recorder):
         self._multimeter = Multimeter()
         self._spike_detector = SpikeDetector()
         recording.Recorder.__init__(self, population, file)
-#        self._create_device()
-
-#    def _create_device(self, variable):
-#        to_memory = (self.file is False) # note file=None means we save to a temporary file, not to memory
-#        if variable is "spikes":
-#            self._device = RecordingDevice("spike_detector", to_memory)
-#        else:
-#            self._device = None
-#            for recorder in self.population.recorders.values():
-#                if hasattr(recorder, "_device") and recorder._device is not None and recorder._device.type == 'multimeter':
-#                    self._device = recorder._device
-#                    break
-#            if self._device is None:
-#                self._device = RecordingDevice("multimeter", to_memory)
-#            self._device.add_variables(*VARIABLE_MAP.get(self.variable, [self.variable]))
 
     def _record(self, variable, new_ids, sampling_interval=None):
         """
@@ -446,9 +228,9 @@ class Recorder(recording.Recorder):
         self._multimeter = Multimeter()
         self._spike_detector = SpikeDetector()
 
-    def _get_spiketimes(self, ids):
+    def _get_spiketimes(self, ids, clear=False):
         # hugely inefficient - to be optimized later
-        return self._spike_detector.get_spiketimes(ids)
+        return self._spike_detector.get_spiketimes(ids, clear=clear)
 
     def _get_all_signals(self, variable, ids, clear=False):
         data = self._multimeter.get_data(variable, ids, clear=clear)
@@ -460,24 +242,6 @@ class Recorder(recording.Recorder):
 
     def _local_count(self, variable, filter_ids):
         assert variable == 'spikes'
-        #N = {}
-        # if self._device.in_memory():
-        #    events = nest.GetStatus(self._device.device, 'events')[0]
-        #    for id in self.filter_recorded(filter):
-        #        mask = events['senders'] == int(id)
-        #        N[int(id)] = len(events['times'][mask])
-        # else:
-        #    spikes = self._get(gather=False, compatible_output=False,
-        #                       filter=filter)
-        #    for id in self.filter_recorded(filter):
-        #        N[int(id)] = 0
-        #    ids   = np.sort(spikes[:,0].astype(int))
-        #    idx   = np.unique(ids)
-        #    left  = np.searchsorted(ids, idx, 'left')
-        #    right = np.searchsorted(ids, idx, 'right')
-        #    for id, l, r in zip(idx, left, right):
-        #        N[id] = r-l
-        # return N
         return self._spike_detector.get_spike_counts(self.filter_recorded('spikes', filter_ids))
 
     def _clear_simulator(self):

--- a/pyNN/nest/recording.py
+++ b/pyNN/nest/recording.py
@@ -127,11 +127,9 @@ class SpikeDetector(RecordingDevice):
 
     def __init__(self, to_memory=True):
         self.device = nest.Create('spike_recorder')
-        device_parameters = {
-            # these seem to have disappeared in NEST v3
-            #"precise_times": True,
-            #"precision": simulator.state.default_recording_precision
-        }
+        device_parameters = {}
+        if not to_memory:
+            device_parameters["precision"] = simulator.state.default_recording_precision
         super(SpikeDetector, self).__init__(device_parameters, to_memory)
 
     def connect_to_cells(self):

--- a/pyNN/nest/simulator.py
+++ b/pyNN/nest/simulator.py
@@ -22,6 +22,7 @@ modules.
 import nest
 import logging
 import tempfile
+import warnings
 import numpy as np
 from pyNN import common
 from pyNN.core import reraise
@@ -90,6 +91,7 @@ class _State(common.control.BaseState):
         self.populations = []  # needed for reset
         self.current_sources = []
         self._time_offset = 0.0
+        self.t_flush = 200.0
         self.stale_connection_cache = False
 
     @property
@@ -195,7 +197,12 @@ class _State(common.control.BaseState):
 
     def reset(self):
         if self.t > 0:
-            self.run(self.max_delay)  # get spikes and recorded data out of the system
+            warnings.warn(
+                "Full reset functionality is not available with NEST. "
+                "Please check carefully that the previous run is not influencing the "
+                "following one and, if so, increase the `t_flush` argument to `setup()`"
+            )
+            self.run(self.t_flush)  # get spikes and recorded data out of the system
             for recorder in self.recorders:
                 recorder._clear_simulator()
 

--- a/pyNN/nest/simulator.py
+++ b/pyNN/nest/simulator.py
@@ -91,7 +91,7 @@ class _State(common.control.BaseState):
         self.populations = []  # needed for reset
         self.current_sources = []
         self._time_offset = 0.0
-        self.t_flush = 200.0
+        self.t_flush = -1
         self.stale_connection_cache = False
 
     @property
@@ -197,11 +197,20 @@ class _State(common.control.BaseState):
 
     def reset(self):
         if self.t > 0:
-            warnings.warn(
-                "Full reset functionality is not available with NEST. "
-                "Please check carefully that the previous run is not influencing the "
-                "following one and, if so, increase the `t_flush` argument to `setup()`"
-            )
+            if self.t_flush < 0:
+                raise ValueError(
+                    "Full reset functionality is not currently available with NEST. "
+                    "If you nevertheless want to use this functionality, pass the `t_flush`"
+                    "argument to `setup()` with a suitably large value (>> 100 ms)"
+                    "then check carefully that the previous run is not influencing the "
+                    "following one."
+                )
+            else:
+                warnings.warn(
+                    "Full reset functionality is not available with NEST. "
+                    "Please check carefully that the previous run is not influencing the "
+                    "following one and, if so, increase the `t_flush` argument to `setup()`"
+                )
             self.run(self.t_flush)  # get spikes and recorded data out of the system
             for recorder in self.recorders:
                 recorder._clear_simulator()

--- a/pyNN/nest/simulator.py
+++ b/pyNN/nest/simulator.py
@@ -22,6 +22,7 @@ modules.
 import nest
 import logging
 import tempfile
+import numpy as np
 from pyNN import common
 from pyNN.core import reraise
 
@@ -94,7 +95,9 @@ class _State(common.control.BaseState):
     @property
     def t(self):
         # note that we always simulate one min delay past the requested time
-        return max(self.t_kernel - self.min_delay - self._time_offset, 0.0)
+        # we round to try to reduce floating-point problems
+        # longer-term, we should probably work with integers (in units of time step)
+        return max(np.around(self.t_kernel - self.min_delay - self._time_offset, decimals=12), 0.0)
 
     t_kernel = nest_property("biological_time", float)
 

--- a/pyNN/nest/simulator.py
+++ b/pyNN/nest/simulator.py
@@ -115,19 +115,18 @@ class _State(common.control.BaseState):
         return nest.Rank()
 
     def _get_spike_precision(self):
-        ogs = nest.GetKernelStatus('off_grid_spiking')
-        return ogs and "off_grid" or "on_grid"
+        return self._spike_precision
 
     def _set_spike_precision(self, precision):
-        self._spike_precision = precision
+        if nest.off_grid_spiking and precision == "on_grid":
+            raise ValueError("The option to use off-grid spiking cannot be turned off once enabled")
         if precision == 'off_grid':
-            nest.SetKernelStatus({'off_grid_spiking': True})
             self.default_recording_precision = 15
         elif precision == 'on_grid':
-            nest.SetKernelStatus({'off_grid_spiking': False})
             self.default_recording_precision = 3
         else:
             raise ValueError("spike_precision must be 'on_grid' or 'off_grid'")
+        self._spike_precision = precision
     spike_precision = property(fget=_get_spike_precision, fset=_set_spike_precision)
 
     def _set_verbosity(self, verbosity):

--- a/pyNN/nest/standardmodels/cells.py
+++ b/pyNN/nest/standardmodels/cells.py
@@ -278,6 +278,7 @@ class SpikeSourceInhGamma(cells.SpikeSourceInhGamma):
     nest_name = {"on_grid": 'inh_gamma_generator',
                  "off_grid":  'inh_gamma_generator'}
     always_local = True
+    uses_parrot = True
     extra_parameters = {
         'origin': 1.0
     }

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -37,9 +37,9 @@ class NestStandardCurrentSource(NestCurrentSource, StandardCurrentSource):
             if id.local and not id.celltype.injectable:
                 raise TypeError("Can't inject current into a spike source.")
         if isinstance(cells, (Population, PopulationView, Assembly)):
-            self.cell_list = [cell for cell in cells]
+            self.cell_list = cells.node_collection
         else:
-            self.cell_list = cells
+            self.cell_list = nest.NodeCollection(cells)
         nest.Connect(self._device, self.cell_list, syn_spec={"delay": state.min_delay})
 
     def _phase_correction(self, start, freq, phase):

--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -39,7 +39,7 @@ class NestStandardCurrentSource(NestCurrentSource, StandardCurrentSource):
         if isinstance(cells, (Population, PopulationView, Assembly)):
             self.cell_list = cells.node_collection
         else:
-            self.cell_list = nest.NodeCollection(cells)
+            self.cell_list = nest.NodeCollection(sorted(cells))
         nest.Connect(self._device, self.cell_list, syn_spec={"delay": state.min_delay})
 
     def _phase_correction(self, start, freq, phase):

--- a/pyNN/nest/synapses.py
+++ b/pyNN/nest/synapses.py
@@ -64,7 +64,7 @@ class NESTSynapseMixin(object):
                     "pyNN.NEST does not support tau_minus being different for different synapses")
             native_parameters.shape = (1,)
             tau_minus = native_parameters["tau_minus"].evaluate(simplify=True)
-            nest.SetStatus(cells.tolist(), [{'tau_minus': tau_minus}])
+            nest.SetStatus(cells, [{'tau_minus': tau_minus}])
 
 
 class NativeSynapseType(BaseSynapseType, NESTSynapseMixin):

--- a/pyNN/nest/synapses.py
+++ b/pyNN/nest/synapses.py
@@ -64,7 +64,7 @@ class NESTSynapseMixin(object):
                     "pyNN.NEST does not support tau_minus being different for different synapses")
             native_parameters.shape = (1,)
             tau_minus = native_parameters["tau_minus"].evaluate(simplify=True)
-            nest.SetStatus(cells, [{'tau_minus': tau_minus}])
+            nest.SetStatus(cells, {'tau_minus': tau_minus})
 
 
 class NativeSynapseType(BaseSynapseType, NESTSynapseMixin):

--- a/pyNN/neuroml/recording.py
+++ b/pyNN/neuroml/recording.py
@@ -66,7 +66,7 @@ class Recorder(recording.Recorder):
 
 
 
-    def _get_spiketimes(self, id):
+    def _get_spiketimes(self, id, clear=False):
 
         if hasattr(id, "__len__"):
             spks = {}

--- a/pyNN/neuron/recording.py
+++ b/pyNN/neuron/recording.py
@@ -113,7 +113,7 @@ class Recorder(recording.Recorder):
     def _get_all_signals(self, variable, ids, clear=False):
         # assuming not using cvode, otherwise need to get times as well and use IrregularlySampledAnalogSignal
         if len(ids) > 0:
-            signals = np.vstack((id._cell.traces[variable] for id in ids)).T
+            signals = np.vstack([id._cell.traces[variable] for id in ids]).T
             expected_length = np.rint(simulator.state.tstop / self.sampling_interval) + 1
             if signals.shape[0] != expected_length:  # generally due to floating point/rounding issues
                 signals = np.vstack((signals, signals[-1, :]))

--- a/pyNN/neuron/recording.py
+++ b/pyNN/neuron/recording.py
@@ -96,7 +96,7 @@ class Recorder(recording.Recorder):
             else:
                 id._cell.clear_past_spikes()
 
-    def _get_spiketimes(self, id):
+    def _get_spiketimes(self, id, clear=False):
         if hasattr(id, "__len__"):
             all_spiketimes = {}
             for cell_id in id:

--- a/pyNN/nineml/connectors.py
+++ b/pyNN/nineml/connectors.py
@@ -8,7 +8,7 @@ Export of PyNN scripts as NineML.
 import nineml.user as nineml
 
 from pyNN import connectors
-from utility import build_parameter_set, catalog_url
+from .utility import build_parameter_set, catalog_url
 
 
 class ConnectorMixin(object):

--- a/pyNN/nineml/projections.py
+++ b/pyNN/nineml/projections.py
@@ -6,7 +6,6 @@ Export of PyNN scripts as NineML.
 :license: CeCILL, see LICENSE for details.
 """
 
-from itertools import repeat, izip
 import nineml.user as nineml
 
 from pyNN import common

--- a/pyNN/parameters.py
+++ b/pyNN/parameters.py
@@ -354,9 +354,12 @@ class ParameterSpace(object):
             self._evaluated_shape = self._shape
         else:
             for name, value in self._parameters.items():
-                if isinstance(value.base_value, RandomDistribution) and value.base_value.rng.parallel_safe:
-                    value = value.evaluate()  # can't partially evaluate if using parallel safe
-                self._parameters[name] = value[mask]
+                try:
+                    if isinstance(value.base_value, RandomDistribution) and value.base_value.rng.parallel_safe:
+                        value = value.evaluate()  # can't partially evaluate if using parallel safe
+                    self._parameters[name] = value[mask]
+                except ValueError:
+                    raise errors.InvalidParameterValueError(f"{name} should not be of type {type(value)}")
             self._evaluated_shape = partial_shape(mask, self._shape)
         self._evaluated = True
         # should possibly update self.shape according to mask?

--- a/pyNN/parameters.py
+++ b/pyNN/parameters.py
@@ -76,7 +76,8 @@ class LazyArray(larray):
         """
         column_indices = np.arange(self.ncols)
         if mask is not None:
-            assert len(mask) == self.ncols
+            if not isinstance(mask, slice):
+                assert len(mask) == self.ncols
             column_indices = column_indices[mask]
         if isinstance(self.base_value, RandomDistribution) and self.base_value.rng.parallel_safe:
             if mask is None:

--- a/pyNN/recording/__init__.py
+++ b/pyNN/recording/__init__.py
@@ -286,6 +286,7 @@ class Recorder(object):
                 ids = sorted(self.filter_recorded(variable, filter_ids))
                 signal_array = self._get_all_signals(variable, ids, clear=clear)
                 t_start = self._recording_start_time
+                t_stop = self._simulator.state.t * pq.ms
                 sampling_period = self.sampling_interval * pq.ms
                 current_time = self._simulator.state.t * pq.ms
                 mpi_node = self._simulator.state.mpi_rank  # for debugging

--- a/pyNN/recording/__init__.py
+++ b/pyNN/recording/__init__.py
@@ -266,7 +266,7 @@ class Recorder(object):
             if variable == 'spikes':
                 t_stop = self._simulator.state.t * pq.ms  # must run on all MPI nodes
                 sids = sorted(self.filter_recorded('spikes', filter_ids))
-                data = self._get_spiketimes(sids)
+                data = self._get_spiketimes(sids, clear=clear)
 
                 segment.spiketrains = []
                 for id in sids:

--- a/pyNN/recording/__init__.py
+++ b/pyNN/recording/__init__.py
@@ -309,7 +309,6 @@ class Recorder(object):
                                  source_ids, signal.channel_index)
                     assert segment.analogsignals[0].t_stop - \
                         current_time - 2 * sampling_period < 1e-10
-                    # need to add `Unit` and `RecordingChannelGroup` objects
         return segment
 
     def get(self, variables, gather=False, filter_ids=None, clear=False,

--- a/test/system/scenarios/test_simulation_control.py
+++ b/test/system/scenarios/test_simulation_control.py
@@ -13,7 +13,7 @@ def test_reset(sim):
     """
     repeats = 3
     dt = 1
-    sim.setup(timestep=dt, min_delay=dt)
+    sim.setup(timestep=dt, min_delay=dt, t_flush=10.0)
     p = sim.Population(1, sim.IF_curr_exp(i_offset=0.1))
     p.record('v')
 
@@ -40,7 +40,7 @@ def test_reset_with_clear(sim):
     """
     repeats = 3
     dt = 1
-    sim.setup(timestep=dt, min_delay=dt)
+    sim.setup(timestep=dt, min_delay=dt, t_flush=10.0)
     p = sim.Population(1, sim.IF_curr_exp(i_offset=0.1))
     p.record('v')
 

--- a/test/system/scenarios/test_simulation_control.py
+++ b/test/system/scenarios/test_simulation_control.py
@@ -70,7 +70,7 @@ def test_reset_with_spikes(sim):
     """
     repeats = 3
     dt = 0.1
-    sim.setup(timestep=dt, min_delay=dt)
+    sim.setup(timestep=dt, min_delay=dt, t_flush=200.0)
     p1 = sim.Population(2, sim.SpikeSourceArray(spike_times=[
         [1.2, 3.8, 9.2],
         [1.5, 1.9, 2.7, 4.8, 6.8],

--- a/test/system/scenarios/test_simulation_control.py
+++ b/test/system/scenarios/test_simulation_control.py
@@ -92,7 +92,7 @@ def test_reset_with_spikes(sim):
                                   data.segments[0].analogsignals[0], 10)
 
 
-test_reset.__test__ = False
+test_reset_with_spikes.__test__ = False
 
 
 @register()

--- a/test/system/scenarios/test_simulation_control.py
+++ b/test/system/scenarios/test_simulation_control.py
@@ -61,6 +61,40 @@ def test_reset_with_clear(sim):
 test_reset_with_clear.__test__ = False
 
 
+
+@register()
+def test_reset_with_spikes(sim):
+    """
+    Run the same simulation n times without recreating the network,
+    and check the results are the same each time.
+    """
+    repeats = 3
+    dt = 0.1
+    sim.setup(timestep=dt, min_delay=dt)
+    p1 = sim.Population(2, sim.SpikeSourceArray(spike_times=[
+        [1.2, 3.8, 9.2],
+        [1.5, 1.9, 2.7, 4.8, 6.8],
+    ]))
+    p2 = sim.Population(2, sim.IF_curr_exp())
+    p2.record('v')
+    prj = sim.Projection(p1, p2, sim.AllToAllConnector(),
+                         sim.StaticSynapse(weight=0.5, delay=0.5))
+
+    for i in range(repeats):
+        sim.run(10.0)
+        sim.reset()
+    data = p2.get_data(clear=False)
+    sim.end()
+
+    assert len(data.segments) == repeats
+    for segment in data.segments[1:]:
+        assert_array_almost_equal(segment.analogsignals[0],
+                                  data.segments[0].analogsignals[0], 10)
+
+
+test_reset.__test__ = False
+
+
 @register()
 def test_setup(sim):
     """

--- a/test/system/test_nest.py
+++ b/test/system/test_nest.py
@@ -160,7 +160,7 @@ def test_random_seeds():
     sim = pyNN.nest
     data = []
     for seed in (854947309, 470924491):
-        sim.setup(threads=1, rng_seeds=[seed])
+        sim.setup(threads=1, rng_seed=seed)
         p = sim.Population(3, sim.SpikeSourcePoisson(rate=100.0))
         p.record('spikes')
         sim.run(100)
@@ -186,8 +186,8 @@ def test_tsodyks_markram_synapse():
                          synapse_type=synapse_type)
     neurons.record('gsyn_inh')
     sim.run(100.0)
-    connections = nest.GetConnections(np.unique(
-        prj._sources).tolist(), synapse_model=prj.nest_synapse_model)
+    connections = nest.GetConnections(nest.NodeCollection(list(prj._sources)),
+                                      synapse_model=prj.nest_synapse_model)
     tau_psc = np.array(nest.GetStatus(connections, 'tau_psc'))
     assert_arrays_equal(tau_psc, np.arange(0.2, 0.7, 0.1))
 
@@ -247,7 +247,7 @@ def test_issue529():
     p1 = sim.Population(10, iaf_neuron(tau_m=20.0, tau_syn_ex=3., tau_syn_in=3.))
     p2 = sim.Population(10, iaf_neuron(tau_m=20.0, tau_syn_ex=3., tau_syn_in=3.))
 
-    nest.SetStatus(list(p2), [{'tau_minus': 20.}])
+    nest.SetStatus(p2.node_collection, {'tau_minus': 20.})
 
     stdp = sim.native_synapse_type("stdp_synapse_hom")(**{
         'lambda': 0.005,

--- a/test/unittests/test_assembly.py
+++ b/test/unittests/test_assembly.py
@@ -334,8 +334,8 @@ class AssemblyTest(unittest.TestCase):
         a1 = a.sample(10, rng=MockRNG())
         # MockRNG.permutation reverses the order
         self.assertEqual(len(a1.populations), 2)
-        assert_array_equal(a1.populations[0].all_cells, p1[11:6:-1])
-        assert_array_equal(a1.populations[1].all_cells, p2[6::-1])
+        assert_array_equal(a1.populations[0].all_cells, sorted(p1[11:6:-1]))
+        assert_array_equal(a1.populations[1].all_cells, sorted(p2[6::-1]))
 
     def test_get_data_with_gather(self, sim=sim):
         t1 = 12.3

--- a/test/unittests/test_nest.py
+++ b/test/unittests/test_nest.py
@@ -23,7 +23,7 @@ class TestFunctions(unittest.TestCase):
     def test_setup(self):
         sim.setup(timestep=0.05, min_delay=0.1, max_delay=1.0,
                   verbosity='debug', spike_precision='off_grid',
-                  recording_precision=4, threads=2, rng_seeds=873465)
+                  recording_precision=4, threads=2, rng_seed=873465)
         ks = nest.GetKernelStatus()
         self.assertEqual(ks['resolution'], 0.05)
         self.assertEqual(ks['local_num_threads'], 2)

--- a/test/unittests/test_nest.py
+++ b/test/unittests/test_nest.py
@@ -30,7 +30,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(ks['rng_seed'], 873465)
         #self.assertEqual(ks['min_delay'], 0.1)
         #self.assertEqual(ks['max_delay'], 1.0)
-        self.assertTrue(ks['off_grid_spiking'])
+        self.assertEqual(sim.state.spike_precision, "off_grid")
 
     def test_run_0(self, ):  # see https://github.com/NeuralEnsemble/PyNN/issues/191
         sim.setup(timestep=0.123, min_delay=0.246)

--- a/test/unittests/test_nest.py
+++ b/test/unittests/test_nest.py
@@ -23,18 +23,14 @@ class TestFunctions(unittest.TestCase):
     def test_setup(self):
         sim.setup(timestep=0.05, min_delay=0.1, max_delay=1.0,
                   verbosity='debug', spike_precision='off_grid',
-                  recording_precision=4, threads=2, rng_seeds=[873465, 3487564])
+                  recording_precision=4, threads=2, rng_seeds=873465)
         ks = nest.GetKernelStatus()
         self.assertEqual(ks['resolution'], 0.05)
         self.assertEqual(ks['local_num_threads'], 2)
-        self.assertEqual(ks['rng_seeds'], (873465, 3487564))
+        self.assertEqual(ks['rng_seed'], 873465)
         #self.assertEqual(ks['min_delay'], 0.1)
         #self.assertEqual(ks['max_delay'], 1.0)
         self.assertTrue(ks['off_grid_spiking'])
-
-    def test_setup_with_rng_seeds(self):
-        sim.setup(rng_seeds_seed=42, threads=3)
-        self.assertEqual(len(nest.GetKernelStatus('rng_seeds')), 3)
 
     def test_run_0(self, ):  # see https://github.com/NeuralEnsemble/PyNN/issues/191
         sim.setup(timestep=0.123, min_delay=0.246)
@@ -184,7 +180,7 @@ class TestProjection(unittest.TestCase):
             weight=0.5, delay=1.0, dendritic_delay_fraction=1.0)
         prj = sim.Projection(self.p1, self.p2, self.all2all,
                              synapse_type=stdp_model)
-        actual_tau_minus = nest.GetStatus([prj.post[0]], "tau_minus")[0]
+        actual_tau_minus = nest.GetStatus(prj.post.node_collection[0], "tau_minus")[0]
         self.assertEqual(intended_tau_minus, actual_tau_minus)
 
 

--- a/test/unittests/test_population.py
+++ b/test/unittests/test_population.py
@@ -235,7 +235,7 @@ class PopulationTest(unittest.TestCase):
             [7, 4, 8, 12, 0, 3, 9, 1, 2, 11, 5, 10, 6]))
         pv = p.sample(5, rng=rng)
         assert_array_equal(pv.all_cells,
-                           p.all_cells[[7, 4, 8, 12, 0]])
+                           sorted(p.all_cells[[7, 4, 8, 12, 0]]))
 
     def test_get_multiple_homogeneous_params_with_gather(self, sim=sim):
         p = sim.Population(4, sim.IF_cond_exp(

--- a/test/unittests/test_populationview.py
+++ b/test/unittests/test_populationview.py
@@ -250,7 +250,7 @@ class PopulationViewTest(unittest.TestCase):
         rng.permutation = Mock(return_value=np.array([3, 1, 0, 2, 4]))
         pv2 = pv1.sample(3, rng=rng)
         assert_array_equal(pv2.all_cells,
-                           p.all_cells[[10, 3, 0]])
+                           sorted(p.all_cells[[10, 3, 0]]))
 
     def test_get_multiple_homogeneous_params_with_gather(self, sim=sim):
         p = sim.Population(10, sim.IF_cond_exp, {


### PR DESCRIPTION
Two major groups of changes:

1. Use NodeCollection instead of lists of gids
2. Resetting the network state to time zero is now difficult or impossible, so instead we never reset the NEST kernel, but instead adjust the PyNN state to make it appear as though we have (e.g. keeping track of the offset between NEST kernel time and PyNN time)

Still to do: update C++ code for NEST extensions. These extensions anyway had no unit tests. This will be done in a separate PR.