### PR TITLE
update subprocess call in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,8 @@ def run_command(path, working_directory):
                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                          universal_newlines=True,
                          cwd=working_directory)
-    result = p.wait()
-    stdout = p.stdout.readlines()
-    return result, stdout
+    stdout = p.communicate()[0]
+    return p.returncode, stdout
 
 
 class build(_build):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def run_command(path, working_directory):
                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                          universal_newlines=True,
                          cwd=working_directory)
-    stdout = p.communicate()[0]
+    stdout, stderr = p.communicate()
     return p.returncode, stdout
 
 


### PR DESCRIPTION
Fixes installation problem on Windows systems.

Currently users might see the installation getting stuck on running
`pip install pyNN`
or locally
`python setup.py install`

Gets stuck at this stage:
![image](https://user-images.githubusercontent.com/24866517/137519182-1750a534-96aa-4a95-b796-0fda15993916.png)

This arises from this method in setup.py
```python
def run_command(path, working_directory):
    p = subprocess.Popen(path, shell=True, stdin=subprocess.PIPE,
                         stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                         universal_newlines=True,
                         cwd=working_directory)
    result = p.wait()
    stdout = p.stdout.readlines()
    return result, stdout
```

On investigating, it was found that the execution gets stuck at `result = p.wait()`

The use of `wait()` is potentially problematic. As mentioned in the [docs](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait):

![image](https://user-images.githubusercontent.com/24866517/137519507-24ac41c4-9d87-4ab3-a9b2-7f7da66c29e4.png)

This PR takes the above suggestion of replacing `wait()` with `communicate()`, and making other related changes.

An alernative workaround, that also I found working, was:

```python
import tempfile

def run_command(path, working_directory):
    with tempfile.NamedTemporaryFile(mode="w+") as tmp_out, tempfile.NamedTemporaryFile(mode="w+") as tmp_err:

        p = subprocess.Popen(path, shell=True, stdin=subprocess.PIPE,
                            stdout=tmp_out, stderr=tmp_err,
                            universal_newlines=True,
                            cwd=working_directory)
        result = p.wait()
        tmp_out.seek(0)
        tmp_err.seek(0)
        stdout = tmp_out.readlines()
    return result, stdout
```
I would prefer the workaround in the PR more suitable, than the above option.
