### PR TITLE
Change Figure.show()

### DIFF
--- a/pyNN/utility/plotting.py
+++ b/pyNN/utility/plotting.py
@@ -213,7 +213,7 @@ class Figure(object):
         self.fig.savefig(filename)
 
     def show(self):
-        self.fig.show()
+        plt.show()
 
 
 class Panel(object):


### PR DESCRIPTION
Change fig.show() to plt.show()
Note that this will block; figure needs to be closed for rest of code to continue.

In regular usage, I presume Figure.save() to be more used.