### PR TITLE
Fix quantities error and x-y order in plotting

### DIFF
--- a/pyNN/utility/plotting.py
+++ b/pyNN/utility/plotting.py
@@ -127,12 +127,12 @@ def plot_spiketrainlist(ax, spiketrains, label='', **options):
     """
     Plot all spike trains in a Segment in a raster plot.
     """
-    ax.set_xlim(spiketrains.t_start, spiketrains.t_stop / ms)
+    ax.set_xlim(spiketrains.t_start, spiketrains.t_stop)
     handle_options(ax, options)
     channel_ids, spike_times = spiketrains.multiplexed
     max_id = max(spiketrains.all_channel_ids)
     min_id = min(spiketrains.all_channel_ids)
-    ax.plot(channel_ids, spike_times, 'k.', **options)
+    ax.plot(spike_times, channel_ids, 'k.', **options)
     ax.set_ylabel("Neuron index")
     ax.set_ylim(-0.5 + min_id, max_id + 0.5)
     if label:


### PR DESCRIPTION
Prior to this commit, running small_network.py --plot-figure will fail with 'Unable to convert between units of "dimensionless" and "ms"' error. This commit also fixes the x-y order in plotting.

Before:

```
raise ValueError(
ValueError: Unable to convert between units of "dimensionless" and "ms"
```

<img width="452" alt="image" src="https://user-images.githubusercontent.com/6127678/198964075-73fff0a4-5431-40ff-84e7-1b9e387cf1c1.png">

After:

<img width="455" alt="image" src="https://user-images.githubusercontent.com/6127678/198964105-5876a4e4-206f-47c0-a511-164c41e638de.png">
