### PR TITLE
feat(nest): update nest extension installation dir

### DIFF
--- a/pyNN/nest/extensions/CMakeLists.txt
+++ b/pyNN/nest/extensions/CMakeLists.txt
@@ -168,7 +168,7 @@ execute_process(
 set( CMAKE_MACOSX_RPATH ON )
 
 # Install all stuff to NEST's install directories.
-set( CMAKE_INSTALL_LIBDIR ${NEST_LIBDIR}/nest CACHE STRING "object code libraries (lib/nest or lib64/nest or lib/<multiarch-tuple>/nest on Debian)" FORCE )
+set( CMAKE_INSTALL_LIBDIR ${NEST_LIBDIR} CACHE STRING "object code libraries (lib/nest or lib64/nest or lib/<multiarch-tuple>/nest on Debian)" FORCE )
 set( CMAKE_INSTALL_DOCDIR ${NEST_DOCDIR} CACHE STRING "documentation root (DATAROOTDIR/doc/nest)" FORCE )
 set( CMAKE_INSTALL_DATADIR ${NEST_DATADIR} CACHE STRING "read-only architecture-independent data (DATAROOTDIR/nest)" FORCE )
 


### PR DESCRIPTION
The `/nest` bit seems to be included in `NEST_LIBDIR` now, so does not need to be explicitly added:

https://github.com/nest/nest-extension-module/blob/master/CMakeLists.txt#L178

I expect `nest-config --libdir` provides the complete path already.