### PR TITLE
Harmonize spike train annotations

### DIFF
--- a/doc/pyplots/neo_example.py
+++ b/doc/pyplots/neo_example.py
@@ -32,14 +32,14 @@ plt.figure(1, figsize=(6, 8))
 
 def plot_spiketrains(segment):
     for spiketrain in segment.spiketrains:
-        y = np.ones_like(spiketrain) * spiketrain.annotations['source_id']
+        y = np.ones_like(spiketrain) * spiketrain.annotations['channel_id']
         plt.plot(spiketrain, y, '.')
         plt.ylabel(segment.name)
         plt.setp(plt.gca().get_xticklabels(), visible=False)
 
 
 def plot_signal(signal, index, colour='b'):
-    label = "Neuron %d" % signal.annotations['source_ids'][index]
+    label = "Neuron %d" % signal.annotations['channel_ids'][index]
     plt.plot(signal.times, signal[:, index], colour, label=label)
     plt.ylabel("%s (%s)" % (signal.name, signal.units._dimensionality.string))
     plt.setp(plt.gca().get_xticklabels(), visible=False)

--- a/pyNN/serialization/sonata.py
+++ b/pyNN/serialization/sonata.py
@@ -98,7 +98,7 @@ class SonataIO(BaseIO):
                                t_stop=spike_times.max() + 1.0,
                                t_start=0.0,
                                units='ms',
-                               source_id=gid)
+                               channel_id=gid)
             )
         block.segments.append(segment)
         return [block]


### PR DESCRIPTION
When moving to using the new SpikeTrainList object in Neo, the annotations weren't fully harmonized between the "create from tuple" and "create from list" pathways, which led to the following error when using pyNN.nest with MPI:
```
$ mpirun -np 2 `which python` small_network.py nest
Traceback (most recent call last):
  File "/home/andrew/dev/PyNN/examples/small_network.py", line 88, in <module>
    cells.write_data(filename, annotations={'script_name': __file__})
  File "/home/andrew/dev/PyNN/pyNN/common/populations.py", line 502, in write_data
    self.recorder.write(variables, io, gather, self._record_filter, clear=clear,
  File "/home/andrew/dev/PyNN/pyNN/recording/__init__.py", line 469, in write
    data = self.get(variables, gather, filter_ids, clear, annotations=annotations,
  File "/home/andrew/dev/PyNN/pyNN/recording/__init__.py", line 440, in get
    data = gather_blocks(data)
  File "/home/andrew/dev/PyNN/pyNN/recording/__init__.py", line 107, in gather_blocks
    ordered_spiketrains = sorted(
  File "/home/andrew/dev/PyNN/pyNN/recording/__init__.py", line 108, in <lambda>
    segment.spiketrains, key=lambda s: s.annotations['source_id'])
KeyError: 'source_id'
```

This PR changes the "source_id" annotation to "channel_id", which is auto-generated by Neo when creating SpikeTrainLists from a pair of arrays (id, times). It also ensures the "source_index" annotation is always present.