### PR TITLE
add eprop-iaf-adapt NEST model

### DIFF
--- a/pyNN/nest/standardmodels/cells.py
+++ b/pyNN/nest/standardmodels/cells.py
@@ -396,6 +396,32 @@ class EIF_cond_exp_isfa_ista(cells.EIF_cond_exp_isfa_ista):
                  "off_grid": "aeif_cond_exp"}
     standard_receptor_type = True
 
+class IF_eprop_adaptive(cells.IF_eprop_adaptive):
+
+    __doc__ = cells.IF_eprop_adaptive.__doc__
+
+    translations = build_translations(
+        ('adapt_beta', 'adapt_beta'),
+        ('adapt_tau',  'adapt_tau'),
+        ('cm',         'C_m',       1000.0),  # nF -> pF
+        ('c_reg',      'c_reg'),
+        ('v_rest',     'E_L'),
+        ('f_target',   'f_target'),
+        ('gamma',      'gamma'),
+        ('i_offset',   'I_e',       1000.0),  # nA -> pA
+        ('reg_spike_arr', 'regular_spike_arrival'),
+        ('surrogate_gradient_function', 'surrogate_gradient_function'),
+        ('tau_refrac', 't_ref'),
+        ('tau_m', 'tau_m'),        
+        ('v_min',      'V_min'),
+        ('v_thresh',   'V_th'),
+    )
+    variable_map = {'v': 'V_m', 'v_th_adapt': 'V_th_adapt', 'adaptation': 'adaptation', 'learning_signal': 'learning_signal', 'surrogate_gradient': 'surrogate_gradient'}
+    scale_factors = {'v': 1, 'v_th_adapt': 1, 'adaptation': 1, 'learning_signal': 1, 'surrogate_gradient': 1}
+    nest_name = {"on_grid": "eprop_iaf_adapt_bsshslm_2020",
+                 "off_grid": "eprop_iaf_adapt_bsshslm_2020"}
+    standard_receptor_type = True
+
 
 class Izhikevich(cells.Izhikevich):
     __doc__ = cells.Izhikevich.__doc__

--- a/pyNN/standardmodels/cells.py
+++ b/pyNN/standardmodels/cells.py
@@ -684,6 +684,58 @@ class PointNeuron(StandardCellType):
                        for psr in self.post_synaptic_receptors.values()])
         )
 
+class IF_eprop_adaptive(StandardCellType):
+    """
+    Implementation of a leaky integrate-and-fire neuron model with delta-shaped 
+    postsynaptic currents and threshold adaptation used for 
+    eligibility propagation (e-prop) plasticity.
+
+    Bellec G, Scherr F, Subramoney F, Hajek E, Salaj D, Legenstein R, Maass W (2020). 
+    A solution to the learning dilemma for recurrent networks of spiking neurons. 
+    Nature Communications, 11:3625. https://doi.org/10.1038/s41467-020-17236-y
+    """
+
+    default_parameters = {
+        'adapt_beta': 1.0,  # Prefactor of threshold adaptation
+        'adapt_tau': 10.0,  # Time constant of threshold adaptation in ms
+        'cm': 0.250,  # Membrane capacitance in nF
+        'c_reg': 0.0,  # Regularization factor
+        'v_rest': -70.0,  # Resting membrane potential in mV
+        'f_target': 10.0,  # Target firing rate of regularization factor in Hz
+        'gamma': 0.3,  # Scaling of surrogate gradient
+        'i_offset': 0.0,  # Offset current in nA
+        'reg_spike_arr': True,  # Regularize spike arrival times
+        'surrogate_gradient_function': 'piecewise_linear',  # Surrogate gradient function
+        'tau_refrac': 2.0,  # Refractory period in ms
+        'tau_m': 10.0,  # Membrane time constant in ms
+        'v_min': -1.79e308,  # Minimum membrane potential in mV
+        'v_thresh': -55.0,  # Spike threshold in mV
+    }
+
+    recordable = ['v', 'spikes', 'adaptation', 'v_th_adapt', 'learning_signal', 'surrogate_gradient']
+    
+    default_initial_values = {
+        'adaptation': 0.0,  # Adaptation variable
+        'learning_signal': 0.0,  # Learning signal
+        'surrogate_gradient': 0.0,  # Surrogate gradient
+        'v': -70.0,  # Membrane potential
+        'v_th_adapt': -55.0,  # Threshold adaptation variable
+    }
+    
+    units = {
+        'adapt_tau': 'ms',
+        'cm': 'nF',
+        'v_rest': 'mV',
+        'f_target': 'Hz',
+        'i_offset': 'nA',
+        't_ref': 'ms',
+        'tau_m': 'ms',
+        'v_min': 'mV',
+        'v_thresh': 'mV',
+        'v': 'mV',
+        'v_th_adapt': 'mV',
+    }
+
 
 class Izhikevich(StandardCellType):
     """


### PR DESCRIPTION
Added [eprop_iaf_adapt_bsshslm_2020 – Current-based leaky integrate-and-fire neuron model with delta-shaped postsynaptic currents and threshold adaptation for e-prop plasticity](https://nest-simulator.readthedocs.io/en/stable/models/eprop_iaf_adapt_bsshslm_2020.html)