### PR TITLE
Fix content overflow in doc sidebar

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -119,7 +119,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'  # 'agogo', 'haiku'
+html_theme = 'sphinxawesome_theme'  # 'agogo', 'haiku'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Fixes #791

Changes:
- `html_theme = 'nature'` to `html_theme = 'sphinxawesome_theme'`
- Screenshot after changes:
<img width="958" alt="fix_overflow" src="https://github.com/user-attachments/assets/12a163ed-48e1-4001-97fc-06dc36108eb2" />

