### PR TITLE
end simulation correction when simulation has callbacks

### DIFF
--- a/pyNN/common/control.py
+++ b/pyNN/common/control.py
@@ -79,7 +79,7 @@ def build_run(simulator):
         if callbacks:
             callback_events = [(callback(simulator.state.t), callback)
                                for callback in callbacks]
-            while simulator.state.t + 1e-9 < time_point:
+            while simulator.state.t + 1e-9 < time_point - simulator.state.dt / 2.0:
                 callback_events.sort(key=lambda cbe: cbe[0], reverse=True)
                 next, callback = callback_events.pop()
                 # collapse multiple events that happen within the same timestep

--- a/pyNN/common/control.py
+++ b/pyNN/common/control.py
@@ -79,7 +79,7 @@ def build_run(simulator):
         if callbacks:
             callback_events = [(callback(simulator.state.t), callback)
                                for callback in callbacks]
-            while simulator.state.t + 1e-9 < time_point - simulator.state.dt / 2.0:
+            while simulator.state.t + 1e-9 < time_point - simulator.state.dt:
                 callback_events.sort(key=lambda cbe: cbe[0], reverse=True)
                 next, callback = callback_events.pop()
                 # collapse multiple events that happen within the same timestep


### PR DESCRIPTION
Sometimes with long simulations with callbacks, the simulation never ends. Here is a small correction in the run_until() method in the control.py file that eliminates this issue.