### PR TITLE
fix mod files for C23

### DIFF
--- a/pyNN/neuron/nmodl/gif.mod
+++ b/pyNN/neuron/nmodl/gif.mod
@@ -208,7 +208,7 @@ ENDVERBATIM
             : independent of nhost or which host this instance is on
             : is desired, since each instance on this cpu draws from
             : the same stream
-            value = scop_random(1)
+            value = scop_random()
 VERBATIM
         }
 ENDVERBATIM

--- a/pyNN/neuron/nmodl/quantal_stp.mod
+++ b/pyNN/neuron/nmodl/quantal_stp.mod
@@ -115,7 +115,7 @@ VERBATIM
             return value;
         } else {
 ENDVERBATIM
-            value = scop_random(1)
+            value = scop_random()
 VERBATIM
         }
 ENDVERBATIM

--- a/pyNN/neuron/nmodl/stochastic_synapse.mod
+++ b/pyNN/neuron/nmodl/stochastic_synapse.mod
@@ -68,7 +68,7 @@ VERBATIM
             return value;
         } else {
 ENDVERBATIM
-            value = scop_random(1)
+            value = scop_random()
 VERBATIM
         }
 ENDVERBATIM

--- a/pyNN/neuron/nmodl/stochastic_tsodyksmarkram.mod
+++ b/pyNN/neuron/nmodl/stochastic_tsodyksmarkram.mod
@@ -118,7 +118,7 @@ VERBATIM
             return value;
         } else {
 ENDVERBATIM
-            value = scop_random(1)
+            value = scop_random()
 VERBATIM
         }
 ENDVERBATIM

--- a/pyNN/neuron/nmodl/vecstim.mod
+++ b/pyNN/neuron/nmodl/vecstim.mod
@@ -113,9 +113,9 @@ NET_RECEIVE (w) {
 
 
 VERBATIM
-extern double* vector_vec();
-extern int vector_capacity();
-extern void* vector_arg();
+extern double* vector_vec(void *);
+extern int vector_capacity(void *);
+extern void* vector_arg(int);
 ENDVERBATIM     
 
 PROCEDURE element() {


### PR DESCRIPTION
Function declarations that were `func ()` now do not mean `func (any args)`, now they mean `func (void)`:

https://gcc.gnu.org/gcc-15/porting_to.html

Issue also filed at NEURON: https://github.com/neuronsimulator/nrn/issues/3376