### PR TITLE
Fix links to paper from Davison et al.

### DIFF
--- a/doc/introduction.txt
+++ b/doc/introduction.txt
@@ -25,7 +25,7 @@ Citing PyNN
 If you publish work using or mentioning PyNN, we would appreciate it if you would cite the following paper:
 
 Davison AP, Brüderle D, Eppler JM, Kremkow J, Muller E, Pecevski DA, Perrinet L and Yger P (2009)
-PyNN: a common interface for neuronal network simulators. Front. Neuroinform. 2:11 `doi:10.3389/neuro.11.011.2008 <http://www.frontiersin.org/neuroinformatics/10.3389/neuro.11/011.2008/abstract>`_.
+PyNN: a common interface for neuronal network simulators. Front. Neuroinform. 2:11 `doi:10.3389/neuro.11.011.2008 <https://doi.org/10.3389/neuro.11.011.2008>`_.
 
 
 Questions/Bugs/Enhancements

--- a/doc/publications.txt
+++ b/doc/publications.txt
@@ -53,7 +53,7 @@ Publications about, relating to or using PyNN
 
 * Davison AP, Brüderle D, Eppler J, Kremkow J, Muller E, Pecevski D, Perrinet L and Yger P (2009) **PyNN: a
   common interface for neuronal network simulators.** Front. Neuroinform. 2:11. doi:10.3389/neuro.11.011.2008.
-  `[link] <http://www.frontiersin.org/neuroinformatics/paper/10.3389/neuro.11/011.2008/>`_
+  `[link] <https://doi.org/10.3389/neuro.11.011.2008>`_
 
 * Brüderle D, Muller E, Davison A, Muller E, Schemmel J and Meier K (2009) **Establishing a novel modeling tool: a
   python-based interface for a neuromorphic hardware system.**


### PR DESCRIPTION
Hi, I was reading the introduction and the url `http://www.frontiersin.org/neuroinformatics/10.3389/neuro.11/011.2008/abstract` resulted in a 404.

Changing it to `http://www.frontiersin.org/neuroinformatics/10.3389/neuro.11.011.2008/abstract` would create a working url.

However, using the DOI-link everywhere makes the most sense, I think.
It is also used in the `codemeta.json`.