### PR TITLE
Add infrastucture to simplify setup and use of local test environments

### DIFF
--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -78,7 +78,7 @@ jobs:
         flake8 pyNN --count --exit-zero --max-complexity=20 --max-line-length=127 --statistics
     - name: Run unit and system tests
       run: |
-        pytest -v --cov=pyNN --cov-report=term test
+        pytest -v -n auto --cov=pyNN --cov-report=term test
     - name: Upload coverage data
       run: |
         coveralls --service=github

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,12 @@ examples/*.svg
 /examples/Potjans2014/clean.sh
 /test/benchmarks/*.h5
 
+# Test environment (Makefile targets)
+.local-nest*/
+.nest-src/
+.nest-build/
+.condaenv-*/
+
 # Other
 *.btr
 *.log

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,237 @@
+# PyNN test environment — three options for running the test suite
+#
+# Option A (native):  builds NEST from source into a project-local venv+prefix
+# Option B (Docker):  runs tests in an Ubuntu container with bind-mounted source
+# Option C (conda):   uses micromamba + conda-forge (no compilation)
+#
+# All targets accept NEST_VERSION=<version> to switch NEST versions.
+#
+# Version string format differs between Options A/B and C for pre-releases:
+#   stable:         NEST_VERSION=3.9    (same for all options)
+#   pre-release:    GitHub tag format for A/B (e.g. 3.10.0rc1)
+#                   conda-forge format for C  (e.g. 3.10_rc1)
+#   Check https://github.com/nest/nest-simulator/releases for GitHub tag names.
+
+NEST_VERSION ?= 3.9
+
+# ── Option A: paths and variables ─────────────────────────────────────────────
+NEST_PREFIX       = $(CURDIR)/.local-nest$(NEST_VERSION)
+NEST_PY           = $(NEST_PREFIX)/bin/python3
+NEST_PIP          = $(NEST_PREFIX)/bin/pip
+NEST_PYTEST       = $(NEST_PREFIX)/bin/pytest
+NEST_VENV_STAMP   = $(NEST_PREFIX)/.venv-ready
+NEST_STAMP        = $(NEST_PREFIX)/.nest-installed
+NEST_SRC_DIR      = $(CURDIR)/.nest-src
+NEST_BUILD_DIR    = $(CURDIR)/.nest-build/nest-$(NEST_VERSION)
+NEST_TARBALL      = $(NEST_SRC_DIR)/nest-$(NEST_VERSION).tar.gz
+NEST_SRC_UNPACKED = $(NEST_SRC_DIR)/nest-simulator-$(NEST_VERSION)
+NPROC             = $(shell sysctl -n hw.logicalcpu 2>/dev/null || echo 4)
+# cmake will search /usr/local by default; override if your C deps are elsewhere
+EXTRA_CMAKE_ARGS  ?=
+
+# ── Option B: variables ────────────────────────────────────────────────────────
+DOCKER_IMAGE = pynn-test:nest$(NEST_VERSION)
+# Pass NEST_VERSION as env var so docker-compose.yml substitution picks it up
+COMPOSE      = NEST_VERSION=$(NEST_VERSION) docker compose -f test/docker-compose.yml
+
+# ── Option C: variables ────────────────────────────────────────────────────────
+MICROMAMBA      ?= micromamba
+CONDAENV_PREFIX  = $(CURDIR)/.condaenv-nest$(NEST_VERSION)
+CONDA_ENV_FILE   = test/environment-nest$(NEST_VERSION).yml
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Option A: native venv + NEST built from source
+# ══════════════════════════════════════════════════════════════════════════════
+
+.PHONY: setup
+setup: $(NEST_STAMP)  ## [A] Build NEST $(NEST_VERSION) from source + create venv
+	@echo ""
+	@echo "Setup complete. Run 'make test NEST_VERSION=$(NEST_VERSION)'"
+
+# 1. Create venv and install Python build prerequisites
+# mpi4py must be compiled against the same MPI that NEST will link to,
+# and must be present before cmake runs so NEST can detect it.
+$(NEST_VENV_STAMP):
+	python3 -m venv $(NEST_PREFIX)
+	$(NEST_PIP) install --upgrade pip
+	$(NEST_PIP) install "cython<3.1.0"
+	MPICC=$(MPI_ROOT)/bin/mpicc \
+	    $(NEST_PIP) install --no-binary=mpi4py mpi4py
+	touch $@
+
+# 2. Download NEST tarball
+$(NEST_TARBALL):
+	@mkdir -p $(NEST_SRC_DIR)
+	curl -fL -o $@ \
+	    https://github.com/nest/nest-simulator/archive/refs/tags/v$(NEST_VERSION).tar.gz
+
+# 3. Unpack source and apply backport of NEST PR #3794:
+# "Add missing include needed on macOS 26.4" — <cstddef> was previously
+# available in numerics.h only via transitive includes that macOS 26 removed.
+$(NEST_SRC_UNPACKED): $(NEST_TARBALL)
+	tar xzf $< -C $(NEST_SRC_DIR)
+	sed -i '' 's|#include <cmath>|#include <cmath>\n#include <cstddef>|' \
+	    $(NEST_SRC_UNPACKED)/libnestutil/numerics.h
+	touch $@
+
+# 4. cmake build, install, then install remaining Python deps
+$(NEST_STAMP): $(NEST_VENV_STAMP) $(NEST_SRC_UNPACKED)
+	mkdir -p $(NEST_BUILD_DIR)
+	cd $(NEST_BUILD_DIR) && cmake \
+	    -DCMAKE_INSTALL_PREFIX=$(NEST_PREFIX) \
+	    -DPython_EXECUTABLE=$(NEST_PY) \
+	    -Dwith-mpi=ON \
+	    -Dwith-python=ON \
+	    -Dwith-gsl=ON \
+	    -Dwith-ltdl=ON \
+	    -Dwith-openmp=OFF \
+	    $(EXTRA_CMAKE_ARGS) \
+	    $(NEST_SRC_UNPACKED)
+	cd $(NEST_BUILD_DIR) && make -j$(NPROC)
+	cd $(NEST_BUILD_DIR) && make install
+	# Build and install PyNN NEST extensions (pynn_extensions module)
+	mkdir -p $(NEST_BUILD_DIR)/pynn_extensions
+	cd $(NEST_BUILD_DIR)/pynn_extensions && cmake \
+	    -Dwith-nest=$(NEST_PREFIX)/bin/nest-config \
+	    $(EXTRA_CMAKE_ARGS) \
+	    $(CURDIR)/pyNN/nest/extensions
+	cd $(NEST_BUILD_DIR)/pynn_extensions && make install
+	$(NEST_PIP) install \
+	    "numpy<2" "neuron>=9.0.0" nrnutils "arbor==0.9.0" \
+	    brian2 libNeuroML scipy matplotlib Cheetah3 h5py Jinja2 \
+	    pytest pytest-xdist pytest-cov flake8
+	$(NEST_PIP) install -e .
+	# Compile NEURON .mod mechanisms against the venv's NEURON.
+	# The compiled arm64/ dir lives in the source tree and is version-specific,
+	# so it must be rebuilt whenever the NEURON version changes.
+	cd $(CURDIR)/pyNN/neuron/nmodl && $(NEST_PREFIX)/bin/nrnivmodl .
+	touch $@
+
+.PHONY: test
+test: $(NEST_STAMP)  ## [A] Run full test suite (NEST_VERSION=$(NEST_VERSION))
+	$(NEST_PYTEST) -v -n auto test/
+
+.PHONY: test-unit
+test-unit: $(NEST_STAMP)  ## [A] Unit tests only (no simulator needed)
+	$(NEST_PYTEST) -n auto test/unittests/
+
+.PHONY: test-nest
+test-nest: $(NEST_STAMP)  ## [A] NEST system + scenario tests
+	$(NEST_PYTEST) -n auto test/system/test_nest.py test/system/scenarios/
+
+.PHONY: test-neuron
+test-neuron: $(NEST_STAMP)  ## [A] NEURON system + scenario tests
+	$(NEST_PYTEST) -n auto test/system/test_neuron.py test/system/scenarios/
+
+.PHONY: test-brian2
+test-brian2: $(NEST_STAMP)  ## [A] Brian2 system tests
+	$(NEST_PYTEST) -n auto test/system/test_brian2.py
+
+.PHONY: clean-nmodl
+clean-nmodl:  ## [A] Remove compiled NEURON mechanisms (required before switching NEURON versions)
+	rm -rf $(CURDIR)/pyNN/neuron/nmodl/arm64 \
+	       $(CURDIR)/pyNN/neuron/nmodl/x86_64
+
+.PHONY: clean
+clean:  ## [A] Remove .local-nest$(NEST_VERSION)/ (triggers full rebuild)
+	rm -rf $(NEST_PREFIX)
+
+.PHONY: clean-build
+clean-build:  ## [A] Remove cmake build dir only (retry after cmake failure)
+	rm -rf $(NEST_BUILD_DIR)
+
+.PHONY: clean-all
+clean-all:  ## [A] Remove all .local-nest*/, .nest-build/, .nest-src/
+	rm -rf .local-nest*/ .nest-build/ .nest-src/
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Option B: Docker with bind-mounted source
+# ══════════════════════════════════════════════════════════════════════════════
+
+.PHONY: docker-build
+docker-build:  ## [B] Build Docker image pynn-test:nest$(NEST_VERSION)
+	$(COMPOSE) build
+
+.PHONY: docker-test
+docker-test:  ## [B] Run full test suite in Docker
+	$(COMPOSE) run --rm pynn pytest -v -n auto test/
+
+.PHONY: docker-test-unit
+docker-test-unit:  ## [B] Unit tests in Docker
+	$(COMPOSE) run --rm pynn pytest -n auto test/unittests/
+
+.PHONY: docker-test-nest
+docker-test-nest:  ## [B] NEST tests in Docker
+	$(COMPOSE) run --rm pynn pytest -n auto test/system/test_nest.py test/system/scenarios/
+
+.PHONY: docker-test-neuron
+docker-test-neuron:  ## [B] NEURON tests in Docker
+	$(COMPOSE) run --rm pynn pytest -n auto test/system/test_neuron.py test/system/scenarios/
+
+.PHONY: docker-test-brian2
+docker-test-brian2:  ## [B] Brian2 tests in Docker
+	$(COMPOSE) run --rm pynn pytest -n auto test/system/test_brian2.py
+
+.PHONY: docker-shell
+docker-shell:  ## [B] Interactive bash inside Docker container
+	$(COMPOSE) run --rm pynn bash
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Option C: micromamba + conda-forge (no compilation)
+# Install micromamba first: "${SHELL}" <(curl -L micro.mamba.pm/install.sh)
+# conda-forge RC version string uses underscore: e.g. NEST_VERSION=3.10_rc1
+# ══════════════════════════════════════════════════════════════════════════════
+
+.PHONY: conda-setup
+conda-setup:  ## [C] Create micromamba env .condaenv-nest$(NEST_VERSION)/
+	@test -f $(CONDA_ENV_FILE) || \
+	    (echo "Error: $(CONDA_ENV_FILE) not found."; \
+	     echo "Copy test/environment-nest3.9.yml and update the nest-simulator pin."; \
+	     exit 1)
+	$(MICROMAMBA) env create -p $(CONDAENV_PREFIX) -f $(CONDA_ENV_FILE) -y
+	$(MICROMAMBA) run -p $(CONDAENV_PREFIX) pip install -e .
+
+.PHONY: conda-test
+conda-test:  ## [C] Run full test suite via micromamba
+	$(MICROMAMBA) run -p $(CONDAENV_PREFIX) pytest -v -n auto test/
+
+.PHONY: conda-test-unit
+conda-test-unit:  ## [C] Unit tests via micromamba
+	$(MICROMAMBA) run -p $(CONDAENV_PREFIX) pytest -n auto test/unittests/
+
+.PHONY: conda-test-nest
+conda-test-nest:  ## [C] NEST tests via micromamba
+	$(MICROMAMBA) run -p $(CONDAENV_PREFIX) \
+	    pytest -n auto test/system/test_nest.py test/system/scenarios/
+
+.PHONY: conda-test-neuron
+conda-test-neuron:  ## [C] NEURON tests via micromamba
+	$(MICROMAMBA) run -p $(CONDAENV_PREFIX) \
+	    pytest -n auto test/system/test_neuron.py test/system/scenarios/
+
+.PHONY: conda-test-brian2
+conda-test-brian2:  ## [C] Brian2 tests via micromamba
+	$(MICROMAMBA) run -p $(CONDAENV_PREFIX) pytest -n auto test/system/test_brian2.py
+
+.PHONY: conda-shell
+conda-shell:  ## [C] Interactive shell via micromamba
+	$(MICROMAMBA) run -p $(CONDAENV_PREFIX) bash
+
+.PHONY: conda-clean
+conda-clean:  ## [C] Remove .condaenv-nest$(NEST_VERSION)/
+	rm -rf $(CONDAENV_PREFIX)
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Help
+# ══════════════════════════════════════════════════════════════════════════════
+
+.PHONY: help
+help:  ## Show available targets
+	@echo "Usage: make <target> [NEST_VERSION=3.9]"
+	@echo ""
+	@grep -E '^[a-zA-Z0-9_-]+:.*##' $(MAKEFILE_LIST) | \
+	    awk 'BEGIN {FS = ":.*##"}; {printf "  %-26s %s\n", $$1, $$2}'
+	@echo ""
+	@echo "Current NEST_VERSION: $(NEST_VERSION)"
+
+.DEFAULT_GOAL := help

--- a/pyNN/nest/simulator.py
+++ b/pyNN/nest/simulator.py
@@ -73,6 +73,13 @@ def build_extensions(build_dir=None):
         warnings.warn("Cannot create build directory for nest extensions")
         return
 
+    # Remove any stale CMakeCache.txt so cmake re-detects the SDK and toolchain.
+    stale_cache = os.path.join(nest_build_dir, "CMakeCache.txt")
+    try:
+        os.remove(stale_cache)
+    except FileNotFoundError:
+        pass
+
     source_dir = os.path.join(os.path.dirname(__file__), "extensions")
     result, stdout = run_command(f"cmake -Dwith-nest={nest_config} {source_dir}",
                                  nest_build_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-cov", "flake8", "wheel", "mpi4py", "scipy", "matplotlib", "Cheetah3", "h5py", "Jinja2"]
+test = ["pytest", "pytest-xdist", "pytest-cov", "flake8", "wheel", "mpi4py", "scipy", "matplotlib", "Cheetah3", "h5py", "Jinja2"]
 doc = ["sphinx"]
 examples = ["matplotlib", "scipy"]
 plotting = ["matplotlib", "scipy"]

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,60 @@
+ARG NEST_VERSION=3.9
+FROM python:3.12-slim
+
+ARG NEST_VERSION
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libltdl-dev \
+    libgsl-dev \
+    libopenmpi-dev \
+    openmpi-bin \
+    cmake \
+    make \
+    wget \
+    g++ \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# cython must be <3.1.0 for NEST to compile
+RUN pip install --no-cache-dir "cython<3.1.0"
+
+# Build NEST from source (mirrors .github/workflows/full-test.yml)
+RUN wget -q https://github.com/nest/nest-simulator/archive/refs/tags/v${NEST_VERSION}.tar.gz \
+    && tar xzf v${NEST_VERSION}.tar.gz \
+    && mkdir nest-build \
+    && cd nest-build \
+    && cmake \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
+        -Dwith-mpi=ON \
+        -Dwith-python=ON \
+        -Dwith-gsl=ON \
+        -Dwith-ltdl=ON \
+        -Dwith-openmp=OFF \
+        ../nest-simulator-${NEST_VERSION} \
+    && make -j$(nproc) \
+    && make install \
+    && cd .. && rm -rf nest-simulator-${NEST_VERSION} nest-build v${NEST_VERSION}.tar.gz
+
+# Build and install PyNN NEST extensions (pynn_extensions module).
+# Copied from the source tree so the image works without the bind mount at build time.
+COPY pyNN/nest/extensions /tmp/pynn-nest-extensions/
+RUN mkdir /tmp/pynn-ext-build \
+    && cd /tmp/pynn-ext-build \
+    && cmake -Dwith-nest=/usr/local/bin/nest-config /tmp/pynn-nest-extensions \
+    && make install \
+    && rm -rf /tmp/pynn-ext-build /tmp/pynn-nest-extensions
+
+# Install PyNN's declared dependencies from its metadata.
+# The source tree is bind-mounted at runtime; only the deps need to live in the image.
+# A minimal stub package satisfies the install without baking in the real source.
+COPY pyproject.toml /tmp/pynn-meta/
+RUN mkdir -p /tmp/pynn-meta/pyNN && touch /tmp/pynn-meta/pyNN/__init__.py && \
+    pip install --no-cache-dir \
+        "numpy<2" \
+        "/tmp/pynn-meta[test,neuron,brian2,arbor,MPI,sonata,neuroml]" && \
+    rm -rf /tmp/pynn-meta
+
+COPY test/docker-entrypoint.sh /entrypoint.sh
+
+WORKDIR /workspace
+ENTRYPOINT ["/entrypoint.sh"]

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  pynn:
+    image: pynn-test:nest${NEST_VERSION:-3.9}
+    build:
+      context: ..
+      dockerfile: test/Dockerfile
+      args:
+        NEST_VERSION: ${NEST_VERSION:-3.9}
+    volumes:
+      - ..:/workspace
+    environment:
+      PYTHONPATH: /workspace
+    working_dir: /workspace

--- a/test/docker-entrypoint.sh
+++ b/test/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Compile NEURON NMODL mechanisms if not already compiled for this architecture.
+# nrnivmodl must run in the nmodl directory; it creates an arch-named subdirectory
+# (x86_64/ or aarch64/) alongside the .mod files, which is where NEURON looks.
+arch=$(uname -m)
+nmodl_dir=/workspace/pyNN/neuron/nmodl
+if [ -d "$nmodl_dir" ] && [ ! -d "$nmodl_dir/$arch" ]; then
+    echo "Compiling NEURON NMODL mechanisms for $arch ..."
+    cd "$nmodl_dir" && nrnivmodl . >/dev/null 2>&1 || echo "Warning: nrnivmodl failed"
+fi
+
+# Remove any Arbor catalogue compiled for a different OS/architecture.
+# build_mechanisms() skips building if the .so already exists, so a stale
+# macOS Mach-O binary (non-ELF) must be removed before the module is imported.
+catalogue=/workspace/pyNN/arbor/nmodl/PyNN-catalogue.so
+if [ -f "$catalogue" ]; then
+    python3 -c "
+with open('$catalogue', 'rb') as f:
+    is_elf = f.read(4) == b'\x7fELF'
+if not is_elf:
+    import os
+    os.remove('$catalogue')
+    try:
+        os.remove('${catalogue}_')
+    except FileNotFoundError:
+        pass
+"
+fi
+
+# Build Arbor catalogue if absent (either never built or just removed above).
+# Do this once here so pytest-xdist workers don't race to build it simultaneously.
+arbor_nmodl=/workspace/pyNN/arbor/nmodl
+if [ -d "$arbor_nmodl" ] && [ ! -f "$arbor_nmodl/PyNN-catalogue.so" ]; then
+    if command -v arbor-build-catalogue >/dev/null 2>&1; then
+        echo "Building Arbor PyNN catalogue ..."
+        arbor-build-catalogue PyNN "$arbor_nmodl" >/dev/null 2>&1 \
+            || echo "Warning: arbor-build-catalogue failed"
+    fi
+fi
+
+exec "$@"

--- a/test/environment-nest3.9.yml
+++ b/test/environment-nest3.9.yml
@@ -1,0 +1,44 @@
+# micromamba environment for PyNN development with NEST 3.9
+# Uses conda-forge only (no Anaconda default channel).
+#
+# Setup:
+#   micromamba env create -p .condaenv-nest3.9 -f environment-nest3.9.yml -y
+#   micromamba run -p .condaenv-nest3.9 pip install -e .
+#
+# Run tests:
+#   micromamba run -p .condaenv-nest3.9 pytest -v test/
+#
+# Or via Makefile:
+#   make conda-setup [NEST_VERSION=3.9]
+#   make conda-test  [NEST_VERSION=3.9]
+#
+# To lock all package versions for reproducibility:
+#   micromamba env export -p .condaenv-nest3.9 > environment-nest3.9.lock.yml
+
+channels:
+  - conda-forge
+
+dependencies:
+  - python=3.12
+  - nest-simulator=3.9
+  - brian2
+  - numpy<2
+  - scipy
+  - matplotlib
+  - mpi4py
+  - h5py
+  - pip
+  - pip:
+    - arbor==0.9.0
+    - libNeuroML
+    - lazyarray>=0.5.2
+    - neo>=0.13.4
+    - morphio
+    - neuron
+    - nrnutils
+    - Cheetah3
+    - Jinja2
+    - pytest
+    - pytest-xdist
+    - pytest-cov
+    - flake8

--- a/test/system/scenarios/fixtures.py
+++ b/test/system/scenarios/fixtures.py
@@ -1,50 +1,32 @@
-import functools
+import importlib
 import pytest
 
-available_modules = {}
-
-try:
-    import pyNN.neuron
-    available_modules["neuron"] = pyNN.neuron
-except ImportError:
-    pass
-
-try:
-    import pyNN.nest
-    available_modules["nest"] = pyNN.nest
-except ImportError:
-    pass
-
-try:
-    import pyNN.brian2
-    available_modules["brian2"] = pyNN.brian2
-except ImportError:
-    pass
-
-try:
-    import pyNN.arbor
-    available_modules["arbor"] = pyNN.arbor
-except ImportError:
-    pass
+_loaded_modules = {}
 
 
-class SimulatorNotAvailable:
+class LazySimulator:
 
     def __init__(self, sim_name):
-        self.sim_name = sim_name
+        self._sim_name = sim_name
 
-    def setup(self, *args, **kwargs):
-        pytest.skip(f"{self.sim_name} not available")
+    @property
+    def __name__(self):
+        return f"pyNN.{self._sim_name}"
 
+    def __str__(self):
+        return f"pyNN.{self._sim_name}"
 
-def get_simulator(sim_name):
-    if sim_name in available_modules:
-        return pytest.param(available_modules[sim_name], id=sim_name)
-    else:
-        return pytest.param(SimulatorNotAvailable(sim_name), id=sim_name)
+    def __getattr__(self, name):
+        module = _loaded_modules.get(self._sim_name)
+        if module is None:
+            try:
+                module = importlib.import_module(f"pyNN.{self._sim_name}")
+                _loaded_modules[self._sim_name] = module
+            except ImportError:
+                pytest.skip(f"{self._sim_name} not available")
+        return getattr(module, name)
 
 
 def run_with_simulators(*sim_names):
-    sim_modules = (get_simulator(sim_name) for sim_name in sim_names)
-
-    return pytest.mark.parametrize("sim", sim_modules)
+    params = [pytest.param(LazySimulator(name), id=name) for name in sim_names]
+    return pytest.mark.parametrize("sim", params)

--- a/test/system/test_nest.py
+++ b/test/system/test_nest.py
@@ -3,9 +3,17 @@ from numpy.testing import assert_array_equal
 
 try:
     import pyNN.nest
+    import nest as _nest
     have_nest = True
+    try:
+        _nest.SetKernelStatus({'local_num_threads': 2})
+        _nest.ResetKernel()
+        have_nest_threads = True
+    except Exception:
+        have_nest_threads = False
 except ImportError:
     have_nest = False
+    have_nest_threads = False
 
 from pyNN.utility import init_logging
 from pyNN.random import RandomDistribution
@@ -82,6 +90,8 @@ def test_native_stdp_model():
 def test_ticket240():
     if not have_nest:
         pytest.skip("nest not available")
+    if not have_nest_threads:
+        pytest.skip("NEST built without threading support")
     nest = pyNN.nest
     nest.setup(threads=4)
     parameters = {'tau_m': 17.0}
@@ -98,6 +108,8 @@ def test_ticket240():
 def test_ticket244():
     if not have_nest:
         pytest.skip("nest not available")
+    if not have_nest_threads:
+        pytest.skip("NEST built without threading support")
     nest = pyNN.nest
     nest.setup(threads=4)
     p1 = nest.Population(4, nest.IF_curr_exp())

--- a/test/unittests/test_nest.py
+++ b/test/unittests/test_nest.py
@@ -3,6 +3,17 @@ try:
     import nest
 except ImportError:
     nest = False
+
+if nest:
+    try:
+        nest.SetKernelStatus({'local_num_threads': 2})
+        nest.ResetKernel()
+        nest_threads_available = True
+    except Exception:
+        nest_threads_available = False
+else:
+    nest_threads_available = False
+
 from pyNN.standardmodels import StandardCellType
 import unittest
 import numpy as np
@@ -20,6 +31,7 @@ class TestFunctions(unittest.TestCase):
         self.assertTrue(len(cell_types) > 10)
         self.assertIsInstance(cell_types[0], str)
 
+    @unittest.skipUnless(nest_threads_available, "NEST built without threading support")
     def test_setup(self):
         sim.setup(timestep=0.05, min_delay=0.1, max_delay=1.0,
                   verbosity='debug', spike_precision='off_grid',


### PR DESCRIPTION
There is now a Makefile (use "make help" for details on the commands) which can set up three different testing environments (venv-based, mamba-based, Docker-based) and run tests in them.

Test runs are also parallelised using pytest-xdist, which makes them much faster on a multi-core machine, plus simulators are only imported as needed.