### PR TITLE
Fix StepCurrentSource.set_parameters() after simulation run (issue #759)

### DIFF
--- a/pyNN/nest/standardmodels/electrodes.py
+++ b/pyNN/nest/standardmodels/electrodes.py
@@ -73,11 +73,12 @@ class NestStandardCurrentSource(NestCurrentSource, StandardCurrentSource):
             raise ValueError("Step current timestamps should be monotonically increasing.")
         # NEST specific: subtract min_delay from times (set to 0.0, if result is negative)
         times = self._delay_correction(times)
-        # find the last element <= dt (we find >dt and then go one element back)
+        # find the last element <= biological_time + dt (we find >biological_time+dt and go one back)
         # this corresponds to the first timestamp that can be used by NEST for current injection
-        ctr = np.searchsorted(times, resolution, side="right") - 1
+        min_time = state.t_kernel + resolution
+        ctr = np.searchsorted(times, min_time, side="right") - 1
         if ctr >= 0:
-            times[ctr] = resolution
+            times[ctr] = min_time
             times = times[ctr:]
             amplitudes = amplitudes[ctr:]
         # map timestamps to actual simulation time instants based on specified dt

--- a/test/system/scenarios/test_electrodes.py
+++ b/test/system/scenarios/test_electrodes.py
@@ -659,6 +659,36 @@ def test_issue631(sim):
     assert (np.all(i_step.magnitude[:int(200.0 / sim_dt) - 1:] == 0))
 
 
+@run_with_simulators("nest")
+def test_issue759(sim):
+    """
+    Test that StepCurrentSource.set_parameters() correctly handles times set at the current
+    simulation time after a run. Previously, times at t=state.t would be sent to NEST as
+    t - min_delay, which is in the past, causing no current injection.
+    """
+    dt = 0.1
+    sim.setup(timestep=dt, min_delay=dt)
+
+    cells = sim.Population(1, sim.IF_curr_exp(v_rest=-65.0, v_thresh=-55.0, tau_refrac=5.0))
+    cells.initialize(v=-65.0)
+    cells.record('spikes')
+
+    cs = sim.StepCurrentSource(times=[0.0], amplitudes=[0.0])
+    cs.inject_into(cells)
+
+    sim.run(50.0)  # no current, no spikes expected
+
+    cs.set_parameters(times=[50.0], amplitudes=[1.0])  # 1.0 nA drives V above threshold
+
+    sim.run(50.0)  # current active, spikes expected
+
+    spikes = cells.get_data().segments[0].spiketrains[0]
+    sim.end()
+
+    assert len(spikes) > 0, "Expected spikes in second run interval; current injection may have failed"
+    assert all(t >= 50.0 for t in spikes.magnitude), "Spikes occurred before current injection started"
+
+
 if __name__ == '__main__':
     from pyNN.utility import get_simulator
     sim, args = get_simulator()


### PR DESCRIPTION
When set_parameters() was called after sim.run(), _check_step_times() used only the timestep (resolution) as the minimum usable amplitude time, ignoring the current simulation time. This produced amplitude_times less than NEST's biological time, causing NEST to silently ignore the current injection.

Fix uses state.t_kernel + resolution (NEST biological time + one step) as the threshold, ensuring the adjusted time is always strictly greater than the current biological time. At t=0 the behaviour is identical to before.