### PR TITLE
Coerce lists/arrays to the expected ArrayParameter subtype in ParameterSpace

### DIFF
--- a/pyNN/parameters.py
+++ b/pyNN/parameters.py
@@ -350,14 +350,14 @@ class ParameterSpace(object):
                         valid_parameter_names=self.schema.keys())
             if issubclass(expected_dtype, ArrayParameter) and isinstance(value, Sized):
                 if len(value) == 0:
-                    value = ArrayParameter([])
+                    value = expected_dtype([])
                 elif not isinstance(value[0], ArrayParameter):
                     # may be a more generic way to do it, but for now this special-casing
                     # seems like the most robust approach
                     if isinstance(value[0], Sized):  # e.g. list of tuples
-                        value = type(value)([ArrayParameter(x) for x in value])
+                        value = type(value)([expected_dtype(x) for x in value])
                     else:
-                        value = ArrayParameter(value)
+                        value = expected_dtype(value)
             try:
                 self._parameters[name] = LazyArray(value, shape=self._shape,
                                                    dtype=expected_dtype)

--- a/test/unittests/test_parameters.py
+++ b/test/unittests/test_parameters.py
@@ -482,6 +482,38 @@ class ParameterSpaceTest(unittest.TestCase):
         assert_array_equal(ps['a'], np.array(
             [Sequence([1, 2, 3]), Sequence([4, 5, 6])], dtype=Sequence))
 
+    def test_create_with_plain_list_produces_sequence(self):
+        schema = {'a': Sequence}
+        ps = ParameterSpace({'a': [1, 2, 3]}, schema, shape=(2,))
+        ps.evaluate()
+        result = ps['a']
+        assert type(result[0]) == Sequence
+        assert_array_equal(result, np.array([Sequence([1, 2, 3]), Sequence([1, 2, 3])], dtype=Sequence))
+
+    def test_create_with_numpy_array_produces_sequence(self):
+        schema = {'a': Sequence}
+        ps = ParameterSpace({'a': np.array([1, 2, 3])}, schema, shape=(2,))
+        ps.evaluate()
+        result = ps['a']
+        assert type(result[0]) == Sequence
+        assert_array_equal(result, np.array([Sequence([1, 2, 3]), Sequence([1, 2, 3])], dtype=Sequence))
+
+    def test_create_with_list_of_numpy_arrays_produces_sequences(self):
+        schema = {'a': Sequence}
+        ps = ParameterSpace({'a': [np.array([1, 2]), np.array([3, 4])]}, schema, shape=(2,))
+        ps.evaluate()
+        result = ps['a']
+        assert type(result[0]) == Sequence
+        assert type(result[1]) == Sequence
+        assert_array_equal(result, np.array([Sequence([1, 2]), Sequence([3, 4])], dtype=Sequence))
+
+    def test_create_with_empty_list_produces_sequence(self):
+        schema = {'a': Sequence}
+        ps = ParameterSpace({'a': []}, schema, shape=(2,))
+        ps.evaluate()
+        result = ps['a']
+        assert type(result[0]) == Sequence
+
     def test_keys(self):
         ps = ParameterSpace({'a': [2, 3, 5, 8, 13], 'b': 7, 'c': lambda i: 3 * i + 2}, shape=(5,))
         assert list(ps.keys()) == ["a", "b", "c"]


### PR DESCRIPTION
When the schema specifies a subclass of ArrayParameter (e.g. Sequence), _setitem_value was hardcoding ArrayParameter as the coercion target. This meant passing a list of numpy arrays as spike_times would produce ArrayParameter elements rather than Sequence elements, causing .get() to fail. Fix by using expected_dtype in all three coercion branches.

Fixes #709